### PR TITLE
Make host optional

### DIFF
--- a/certmanager/generate_cert.go
+++ b/certmanager/generate_cert.go
@@ -151,8 +151,6 @@ func genCertTemplate(options CertOptions) x509.Certificate {
 		extKeyUsage = x509.ExtKeyUsageClientAuth
 	}
 
-	sanExt := buildSubjectAltNameExtension(options.Host)
-
 	template := x509.Certificate{
 		SerialNumber: genSerialNum(),
 		Subject: pkix.Name{
@@ -163,8 +161,13 @@ func genCertTemplate(options CertOptions) x509.Certificate {
 		KeyUsage:              keyUsage,
 		ExtKeyUsage:           []x509.ExtKeyUsage{extKeyUsage},
 		BasicConstraintsValid: true,
-		ExtraExtensions:       []pkix.Extension{sanExt},
 	}
+
+	if h := options.Host; len(h) > 0 {
+		s := buildSubjectAltNameExtension(h)
+		template.ExtraExtensions = []pkix.Extension{s}
+	}
+
 	if options.IsCA {
 		template.IsCA = true
 		template.KeyUsage |= x509.KeyUsageCertSign

--- a/cmd/generate_cert/main.go
+++ b/cmd/generate_cert/main.go
@@ -47,9 +47,7 @@ var (
 
 func checkCmdLine() {
 	flag.Parse()
-	if len(*host) == 0 {
-		log.Fatalf("Missing required --host parameter.")
-	}
+
 	hasCert, hasPriv := len(*signerCertFile) != 0, len(*signerPrivFile) != 0
 	if *isSelfSigned {
 		if hasCert || hasPriv {


### PR DESCRIPTION
This allows us to generate root/intermediate CA certicates.

Fix #46