### PR TITLE
Expose ParsePemEncodedCertificate in certmanager

### DIFF
--- a/certmanager/ca.go
+++ b/certmanager/ca.go
@@ -87,7 +87,7 @@ func NewIstioCA(opts *IstioCAOptions) (*IstioCA, error) {
 	ca.certChainBytes = copyBytes(opts.CertChainBytes)
 	ca.rootCertBytes = copyBytes(opts.RootCertBytes)
 
-	ca.signingCert = parsePemEncodedCertificate(opts.SigningCertBytes)
+	ca.signingCert = ParsePemEncodedCertificate(opts.SigningCertBytes)
 	ca.signingKey = parsePemEncodedKey(ca.signingCert.PublicKeyAlgorithm, opts.SigningKeyBytes)
 
 	if err := ca.verify(); err != nil {

--- a/certmanager/ca_test.go
+++ b/certmanager/ca_test.go
@@ -38,7 +38,7 @@ func TestSelfSignedIstioCA(t *testing.T) {
 	rootPool := x509.NewCertPool()
 	rootPool.AppendCertsFromPEM(ca.GetRootCertificate())
 
-	cert := parsePemEncodedCertificate(cb)
+	cert := ParsePemEncodedCertificate(cb)
 	chain, err := cert.Verify(x509.VerifyOptions{
 		Intermediates: certPool,
 		Roots:         rootPool,

--- a/certmanager/generate_cert.go
+++ b/certmanager/generate_cert.go
@@ -127,7 +127,7 @@ func LoadSignerCredsFromFiles(signerCertFile string, signerPrivFile string) (*x5
 		glog.Fatalf("Reading private key file failed with error %s.", err)
 	}
 
-	cert := parsePemEncodedCertificate(signerCertBytes)
+	cert := ParsePemEncodedCertificate(signerCertBytes)
 	key := parsePemEncodedKey(cert.PublicKeyAlgorithm, signerPrivBytes)
 
 	return cert, key

--- a/certmanager/generate_cert_test.go
+++ b/certmanager/generate_cert_test.go
@@ -67,7 +67,7 @@ func TestGenCert(t *testing.T) {
 		org:         "MyOrg",
 	})
 
-	caCert := parsePemEncodedCertificate(caCertPem)
+	caCert := ParsePemEncodedCertificate(caCertPem)
 	caPriv := parsePemEncodedKey(caCert.PublicKeyAlgorithm, caPrivPem)
 	cases := []struct {
 		certOptions  CertOptions

--- a/certmanager/util.go
+++ b/certmanager/util.go
@@ -22,8 +22,9 @@ import (
 	"github.com/golang/glog"
 )
 
-// Given a PEM-encoded certificate, construct a `x509.Certificate` object.
-func parsePemEncodedCertificate(certBytes []byte) *x509.Certificate {
+// ParsePemEncodedCertificate constructs a `x509.Certificate` object using the
+// given a PEM-encoded certificate,
+func ParsePemEncodedCertificate(certBytes []byte) *x509.Certificate {
 	cb, _ := pem.Decode(certBytes)
 	if cb == nil {
 		glog.Fatalf("Invalid PEM encoding for the certificate: %s", certBytes)

--- a/certmanager/util_test.go
+++ b/certmanager/util_test.go
@@ -103,7 +103,7 @@ TmngRSxv/dSvGA==
 	}
 
 	for _, c := range testCases {
-		cert := parsePemEncodedCertificate([]byte(c.cert))
+		cert := ParsePemEncodedCertificate([]byte(c.cert))
 		key := parsePemEncodedKey(cert.PublicKeyAlgorithm, []byte(c.key))
 		if keyType := reflect.TypeOf(key); keyType != c.keyType {
 			t.Errorf("Unmatched key type: expected %v but got %v", c.keyType, keyType)


### PR DESCRIPTION
This method will be used by the secret controller to re-parse
certificate saved into a secret to examine certificate expiration time.