### PR TITLE
Stop glog from emitting false negative errors

### DIFF
--- a/bin/e2e.sh
+++ b/bin/e2e.sh
@@ -56,4 +56,4 @@ docker tag bazel/docker:$DOCKER_IMAGE $HUB/$DOCKER_IMAGE:$TAG
 docker push $HUB/$DOCKER_IMAGE:$TAG
 
 # Run integration tests
-bazel run $BAZEL_ARGS //integration -- $ARGS -k /home/jenkins/.kube/config
+bazel run $BAZEL_ARGS //integration -- $ARGS -k /home/jenkins/.kube/config --alsologtostderr

--- a/integration/main.go
+++ b/integration/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"time"
 
@@ -59,6 +60,12 @@ func init() {
 }
 
 func main() {
+	// HACKHACK: let `flag.Parsed()` return true to prevent glog from emitting errors
+	flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
+	if err := flag.CommandLine.Parse([]string{}); err != nil {
+		glog.Fatal(err)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		glog.Fatal(err)
 	}

--- a/integration/main.go
+++ b/integration/main.go
@@ -57,6 +57,8 @@ func init() {
 	flags.StringVar(&opts.containerImage, "image", "", "Name of Istio CA image")
 	flags.StringVar(&opts.containerTag, "tag", "", "Tag for Istio CA image")
 	flags.StringVarP(&opts.kubeconfig, "kube-config", "k", "~/.kube/config", "path to kubeconfig file")
+
+	AddFlags(rootCmd)
 }
 
 func main() {
@@ -209,4 +211,20 @@ func waitForSecretExist(secretName string, timeToWait time.Duration) (*v1.Secret
 			return nil, fmt.Errorf("secret %v/%v did not become existent within %v", opts.namespace, secretName, timeToWait)
 		}
 	}
+}
+
+// AddFlags carries over glog flags with new defaults
+func AddFlags(rootCmd *cobra.Command) {
+	flag.CommandLine.VisitAll(func(gf *flag.Flag) {
+		switch gf.Name {
+		case "logtostderr":
+			if err := gf.Value.Set("true"); err != nil {
+				fmt.Printf("missing logtostderr flag: %v", err)
+			}
+		case "log_dir", "stderrthreshold":
+			// always use stderr for logging
+		default:
+			rootCmd.PersistentFlags().AddGoFlag(gf)
+		}
+	})
 }


### PR DESCRIPTION
glog prepends "ERROR: logging before flag.Parse:" to each log message
if `flag.Parse()`. However we can't simply call `flag.Parse()` since
CLI options are handled by cobra.

This PR manually forces `flag.Parsed()` to return true to avoid those
annoying messages.

Logic is borrowed from
https://github.com/istio/mixer/blob/master/cmd/server/cmd/root.go#L44