### PR TITLE
Return error instead of logging it

### DIFF
--- a/certmanager/ca.go
+++ b/certmanager/ca.go
@@ -86,8 +86,16 @@ func NewIstioCA(opts *IstioCAOptions) (*IstioCA, error) {
 	ca.certChainBytes = copyBytes(opts.CertChainBytes)
 	ca.rootCertBytes = copyBytes(opts.RootCertBytes)
 
-	ca.signingCert = pki.ParsePemEncodedCertificate(opts.SigningCertBytes)
-	ca.signingKey = pki.ParsePemEncodedKey(ca.signingCert.PublicKeyAlgorithm, opts.SigningKeyBytes)
+	var err error
+	ca.signingCert, err = pki.ParsePemEncodedCertificate(opts.SigningCertBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	ca.signingKey, err = pki.ParsePemEncodedKey(ca.signingCert.PublicKeyAlgorithm, opts.SigningKeyBytes)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := ca.verify(); err != nil {
 		return nil, err

--- a/certmanager/ca_test.go
+++ b/certmanager/ca_test.go
@@ -46,12 +46,18 @@ func TestSelfSignedIstioCA(t *testing.T) {
 	rootPool := x509.NewCertPool()
 	rootPool.AppendCertsFromPEM(rcb)
 
-	cert := pki.ParsePemEncodedCertificate(cb)
+	cert, err := pki.ParsePemEncodedCertificate(cb)
+	if err != nil {
+		t.Error(err)
+	}
 	if ttl := cert.NotAfter.Sub(cert.NotBefore); ttl != certTTL {
 		t.Errorf("Unexpected certificate TTL (expecting %v, actual %v)", certTTL, ttl)
 	}
 
-	rootCert := pki.ParsePemEncodedCertificate(rcb)
+	rootCert, err := pki.ParsePemEncodedCertificate(rcb)
+	if err != nil {
+		t.Error(err)
+	}
 	if ttl := rootCert.NotAfter.Sub(rootCert.NotBefore); ttl != caCertTTL {
 		t.Errorf("Unexpected CA certificate TTL (expecting %v, actual %v)", caCertTTL, ttl)
 	}

--- a/certmanager/generate_cert.go
+++ b/certmanager/generate_cert.go
@@ -154,8 +154,14 @@ func LoadSignerCredsFromFiles(signerCertFile string, signerPrivFile string) (*x5
 		glog.Fatalf("Reading private key file failed with error %s.", err)
 	}
 
-	cert := pki.ParsePemEncodedCertificate(signerCertBytes)
-	key := pki.ParsePemEncodedKey(cert.PublicKeyAlgorithm, signerPrivBytes)
+	cert, err := pki.ParsePemEncodedCertificate(signerCertBytes)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	key, err := pki.ParsePemEncodedKey(cert.PublicKeyAlgorithm, signerPrivBytes)
+	if err != nil {
+		glog.Fatal(err)
+	}
 
 	return cert, key
 }

--- a/certmanager/generate_cert_test.go
+++ b/certmanager/generate_cert_test.go
@@ -117,8 +117,16 @@ func TestGenCert(t *testing.T) {
 		org:         "MyOrg",
 	})
 
-	caCert := pki.ParsePemEncodedCertificate(caCertPem)
-	caPriv := pki.ParsePemEncodedKey(caCert.PublicKeyAlgorithm, caPrivPem)
+	caCert, err := pki.ParsePemEncodedCertificate(caCertPem)
+	if err != nil {
+		t.Error(err)
+	}
+
+	caPriv, err := pki.ParsePemEncodedKey(caCert.PublicKeyAlgorithm, caPrivPem)
+	if err != nil {
+		t.Error(err)
+	}
+
 	cases := []struct {
 		certOptions  CertOptions
 		verifyFields VerifyFields

--- a/controller/secret.go
+++ b/controller/secret.go
@@ -223,7 +223,14 @@ func (sc *SecretController) scrtUpdated(oldObj, newObj interface{}) {
 	}
 
 	certBytes := scrt.Data[CertChainID]
-	cert := pki.ParsePemEncodedCertificate(certBytes)
+	cert, err := pki.ParsePemEncodedCertificate(certBytes)
+	if err != nil {
+		// TODO: we should refresh secret in this case since the secret contains an
+		// invalid cert.
+		glog.Error(err)
+		return
+	}
+
 	ttl := time.Until(cert.NotAfter)
 	rootCertificate := sc.ca.GetRootCertificate()
 

--- a/pkg/pki/crypto.go
+++ b/pkg/pki/crypto.go
@@ -18,48 +18,47 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
-
-	"github.com/golang/glog"
+	"fmt"
 )
 
 // ParsePemEncodedCertificate constructs a `x509.Certificate` object using the
 // given a PEM-encoded certificate,
-func ParsePemEncodedCertificate(certBytes []byte) *x509.Certificate {
+func ParsePemEncodedCertificate(certBytes []byte) (*x509.Certificate, error) {
 	cb, _ := pem.Decode(certBytes)
 	if cb == nil {
-		glog.Fatalf("Invalid PEM encoding for the certificate: %s", certBytes)
+		return nil, fmt.Errorf("Invalid PEM encoded certificate")
 	}
+
 	cert, err := x509.ParseCertificate(cb.Bytes)
 	if err != nil {
-		glog.Fatalf("Failed to parse X.509 certificate (error: %s)", err)
+		return nil, fmt.Errorf("Failed to parse X.509 certificate")
 	}
-	return cert
+
+	return cert, nil
 }
 
 // ParsePemEncodedKey takes a PEM-encoded key, and parsed the bytes into a
 // `crypto.PrivateKey`, using the provided `x509.PublicKeyAlgorithm`.
-func ParsePemEncodedKey(algo x509.PublicKeyAlgorithm, keyBytes []byte) crypto.PrivateKey {
+func ParsePemEncodedKey(algo x509.PublicKeyAlgorithm, keyBytes []byte) (crypto.PrivateKey, error) {
 	kb, _ := pem.Decode(keyBytes)
 	if kb == nil {
-		glog.Fatalf("Invalid PEM encoding for the key: %s", keyBytes)
+		return nil, fmt.Errorf("Invalid PEM-encoded key")
 	}
 
 	switch algo {
 	case x509.RSA:
 		key, err := x509.ParsePKCS1PrivateKey(kb.Bytes)
 		if err != nil {
-			glog.Fatalf("Failed to parse the RSA private key (error: %s)", err)
+			return nil, fmt.Errorf("Failed to parse the RSA private key")
 		}
-		return key
+		return key, nil
 	case x509.ECDSA:
 		key, err := x509.ParseECPrivateKey(kb.Bytes)
 		if err != nil {
-			glog.Fatalf("Failed to parse the ECDSA private key (error: %s)", err)
+			return nil, fmt.Errorf("Failed to parse the ECDSA private key")
 		}
-		return key
+		return key, nil
 	default:
-		glog.Fatalf("Unknown public key algorithm: %d", algo)
+		return nil, fmt.Errorf("Unknown public key algorithm: %d", algo)
 	}
-
-	return nil
 }

--- a/pkg/pki/crypto_test.go
+++ b/pkg/pki/crypto_test.go
@@ -22,67 +22,15 @@ import (
 	"testing"
 )
 
-func TestParsePemEncodedCertificate(t *testing.T) {
-	testCases := map[string]struct {
-		pem           string
-		publicKeyAlgo x509.PublicKeyAlgorithm
-	}{
-		"Parse RSA certificate": {
-			publicKeyAlgo: x509.RSA,
-			pem: `
------BEGIN CERTIFICATE-----
-MIIC+zCCAeOgAwIBAgIQQ0vFSayWg4FQBBr1EpI5rzANBgkqhkiG9w0BAQsFADAT
-MREwDwYDVQQKEwhKdWp1IG9yZzAeFw0xNzAzMTEwNjA0MDJaFw0xODAzMTEwNjA0
-MDJaMBMxETAPBgNVBAoTCEp1anUgb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEAw/OBAAhDu58f0HkJlJBtb42Jp9EECC+WYEOVEdM/Y9fqcoSFb19N
-xztVqy0r/aW8pCO3DZ2EYIA3Y9pYasDfhsIl9lhQkvEwk/05iL6oNrZ45BgsiSK+
-R5OlO9pXtj6HF948qFTDYbYVqki3rAWSSYeGpQ+/s/xcIIIKH5ozKs7DTqR8svQ6
-t7Hxg0vYSUCHfJo25yIvoo8XGZxrFWOZDXfHHC22q8kuuxT82bdQo7KzYhgnuujy
-zIZYqgG9BuUmB6UYdvuDRRDz4HDfERSFFxZbTAaMPNgCRvQnkPS0DJO0XZW2T9m3
-bQvaqTgFI/capuhhgRcP0UrStJKZO7LVHQIDAQABo0swSTAOBgNVHQ8BAf8EBAMC
-BaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAUBgNVHREEDTAL
-gglsb2NhbGhvc3QwDQYJKoZIhvcNAQELBQADggEBAITDuqOhN1jwiA72qSWzOwuy
-bMHPkUTUw2JfICtPS0AlfNNVJXREUi4KoX81ju126PGQeOTApWvS5Kkd6PbNqVH9
-g3myAKrkyjewTfFtK5OOOQGzQT6lCEhKdZJusdqfAMl1heFJGnZ6GAi38ftdz2Z8
-0LPyyIaVBvexNnTPrqoBqdtWyzjYIdMnsSNWJnldmWjwA76sW+vvlLvTONiT4unM
-8ia4GGIw7GK4E/7qxl27q6pXdZkZgG53XItYiUJGAKeBJ2nQfXq0qSmtpHkF17Cu
-hw25X3FJpzRq62JxTx5q6+M2c07g4dkbfMDp/TO7vF4SWruU6JBZj5MVDYn4PEA=
------END CERTIFICATE-----
-			`,
-		},
-		"Parse ECDSA cert": {
-			pem: `
------BEGIN CERTIFICATE-----
-MIIBSzCB+qADAgECAhAzJszEACNBOHrsfSUJMPsHMAoGCCqGSM49BAMCMAsxCTAH
-BgNVBAoTADAeFw0xNzAzMTMwNTE2NThaFw0xNzAzMTMwNTE2NThaMAsxCTAHBgNV
-BAoTADBOMBAGByqGSM49AgEGBSuBBAAhAzoABMKQDHvCFvaTfFab5SOUVYWJXXWh
-iYh1iBeqIBCSLPt8SrpAWGyOMKLN4bMCWFNOaeBFLG/91K8Yo0swSTAOBgNVHQ8B
-Af8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAUBgNV
-HREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDQAAwPQIcY8lgBAAtFWtxmk9k
-BB6nORpwdv4LVt/BFgLwWQIdAKvHn7cxBJ+aAC25rIumRNKDzP7PkV0HDbxtX+M=
------END CERTIFICATE-----
-			`,
-			publicKeyAlgo: x509.ECDSA,
-		},
-	}
+const (
+	keyECDSA = `
+-----BEGIN EC PARAMETERS-----
+MGgCAQEEHBMUyVWFKTW4TwtwCmIAxdpsBFn0MV7tGeSA32CgBwYFK4EEACGhPAM6
+AATCkAx7whb2k3xWm+UjlFWFiV11oYmIdYgXqiAQkiz7fEq6QFhsjjCizeGzAlhT
+TmngRSxv/dSvGA==
+-----END EC PARAMETERS-----`
 
-	for _, c := range testCases {
-		cert := ParsePemEncodedCertificate([]byte(c.pem))
-		if cert.PublicKeyAlgorithm != c.publicKeyAlgo {
-			t.Errorf("Unexpected public key algorithm: want %d but got %d", c.publicKeyAlgo, cert.PublicKeyAlgorithm)
-		}
-	}
-}
-
-func TestParsePemEncodedKey(t *testing.T) {
-	testCases := map[string]struct {
-		algo    x509.PublicKeyAlgorithm
-		pem     string
-		keyType reflect.Type
-	}{
-		"Parse RSA key": {
-			algo: x509.RSA,
-			pem: `
+	keyRSA = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAw/OBAAhDu58f0HkJlJBtb42Jp9EECC+WYEOVEdM/Y9fqcoSF
 b19NxztVqy0r/aW8pCO3DZ2EYIA3Y9pYasDfhsIl9lhQkvEwk/05iL6oNrZ45Bgs
@@ -109,27 +57,130 @@ dmbqEH3EFJnbg5AhRBSYTPj9bICcw7AlQksbonHQlzB/ozEij2V8nZbRQ6b5fQuZ
 as/RmwKBgGPB8PHYHyz0km8LxM/GPstcoO4Ls5coS3MX2EBDKGqWOIOtLKz0azc7
 R4beF5BJE6ulhLig4fkOWH4CIvw2Y1/22GJE/fYjUTRMD57ZdYuKqSyMNxwqiolw
 xGSDfnFvR13RCqeUdlQofVYpolqrSobOyOVfQv2ksnPPsC87NISM
------END RSA PRIVATE KEY-----
-			`,
+-----END RSA PRIVATE KEY-----`
+
+	certRSA = `
+-----BEGIN CERTIFICATE-----
+MIIC+zCCAeOgAwIBAgIQQ0vFSayWg4FQBBr1EpI5rzANBgkqhkiG9w0BAQsFADAT
+MREwDwYDVQQKEwhKdWp1IG9yZzAeFw0xNzAzMTEwNjA0MDJaFw0xODAzMTEwNjA0
+MDJaMBMxETAPBgNVBAoTCEp1anUgb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAw/OBAAhDu58f0HkJlJBtb42Jp9EECC+WYEOVEdM/Y9fqcoSFb19N
+xztVqy0r/aW8pCO3DZ2EYIA3Y9pYasDfhsIl9lhQkvEwk/05iL6oNrZ45BgsiSK+
+R5OlO9pXtj6HF948qFTDYbYVqki3rAWSSYeGpQ+/s/xcIIIKH5ozKs7DTqR8svQ6
+t7Hxg0vYSUCHfJo25yIvoo8XGZxrFWOZDXfHHC22q8kuuxT82bdQo7KzYhgnuujy
+zIZYqgG9BuUmB6UYdvuDRRDz4HDfERSFFxZbTAaMPNgCRvQnkPS0DJO0XZW2T9m3
+bQvaqTgFI/capuhhgRcP0UrStJKZO7LVHQIDAQABo0swSTAOBgNVHQ8BAf8EBAMC
+BaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAUBgNVHREEDTAL
+gglsb2NhbGhvc3QwDQYJKoZIhvcNAQELBQADggEBAITDuqOhN1jwiA72qSWzOwuy
+bMHPkUTUw2JfICtPS0AlfNNVJXREUi4KoX81ju126PGQeOTApWvS5Kkd6PbNqVH9
+g3myAKrkyjewTfFtK5OOOQGzQT6lCEhKdZJusdqfAMl1heFJGnZ6GAi38ftdz2Z8
+0LPyyIaVBvexNnTPrqoBqdtWyzjYIdMnsSNWJnldmWjwA76sW+vvlLvTONiT4unM
+8ia4GGIw7GK4E/7qxl27q6pXdZkZgG53XItYiUJGAKeBJ2nQfXq0qSmtpHkF17Cu
+hw25X3FJpzRq62JxTx5q6+M2c07g4dkbfMDp/TO7vF4SWruU6JBZj5MVDYn4PEA=
+-----END CERTIFICATE-----`
+
+	certECDSA = `
+-----BEGIN CERTIFICATE-----
+MIIBSzCB+qADAgECAhAzJszEACNBOHrsfSUJMPsHMAoGCCqGSM49BAMCMAsxCTAH
+BgNVBAoTADAeFw0xNzAzMTMwNTE2NThaFw0xNzAzMTMwNTE2NThaMAsxCTAHBgNV
+BAoTADBOMBAGByqGSM49AgEGBSuBBAAhAzoABMKQDHvCFvaTfFab5SOUVYWJXXWh
+iYh1iBeqIBCSLPt8SrpAWGyOMKLN4bMCWFNOaeBFLG/91K8Yo0swSTAOBgNVHQ8B
+Af8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAUBgNV
+HREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDQAAwPQIcY8lgBAAtFWtxmk9k
+BB6nORpwdv4LVt/BFgLwWQIdAKvHn7cxBJ+aAC25rIumRNKDzP7PkV0HDbxtX+M=
+-----END CERTIFICATE-----`
+)
+
+func TestParsePemEncodedCertificate(t *testing.T) {
+	testCases := map[string]struct {
+		errMsg        string
+		pem           string
+		publicKeyAlgo x509.PublicKeyAlgorithm
+	}{
+		"Invalid PEM string": {
+			errMsg: "Invalid PEM encoded certificate",
+			pem:    "invalid pem string",
+		},
+		"Invalid certificate string": {
+			errMsg: "Failed to parse X.509 certificate",
+			pem:    keyECDSA,
+		},
+		"Parse RSA certificate": {
+			publicKeyAlgo: x509.RSA,
+			pem:           certRSA,
+		},
+		"Parse ECDSA cert": {
+			pem:           certECDSA,
+			publicKeyAlgo: x509.ECDSA,
+		},
+	}
+
+	for id, c := range testCases {
+		cert, err := ParsePemEncodedCertificate([]byte(c.pem))
+		if c.errMsg != "" {
+			if err == nil {
+				t.Errorf("%s: no error is returned", id)
+			} else if c.errMsg != err.Error() {
+				t.Errorf("%s: Unexpected error message: want %s but got %s", id, c.errMsg, err.Error())
+			}
+		} else {
+			if cert.PublicKeyAlgorithm != c.publicKeyAlgo {
+				t.Errorf("%s: Unexpected public key algorithm: want %d but got %d", id, c.publicKeyAlgo, cert.PublicKeyAlgorithm)
+			}
+		}
+	}
+}
+
+func TestParsePemEncodedKey(t *testing.T) {
+	testCases := map[string]struct {
+		algo    x509.PublicKeyAlgorithm
+		errMsg  string
+		pem     string
+		keyType reflect.Type
+	}{
+		"Invalid key type": {
+			algo:   10,
+			errMsg: "Unknown public key algorithm: 10",
+			pem:    keyECDSA,
+		},
+		"Invalid PEM string": {
+			errMsg: "Invalid PEM-encoded key",
+			pem:    "Invalid PEM string",
+		},
+		"Invalid RSA private key": {
+			algo:   x509.RSA,
+			errMsg: "Failed to parse the RSA private key",
+			pem:    keyECDSA,
+		},
+		"Invalid ECDSA private key": {
+			algo:   x509.ECDSA,
+			errMsg: "Failed to parse the ECDSA private key",
+			pem:    keyRSA,
+		},
+		"Parse RSA key": {
+			algo:    x509.RSA,
+			pem:     keyRSA,
 			keyType: reflect.TypeOf(&rsa.PrivateKey{}),
 		},
 		"Parse ECDSA key": {
-			algo: x509.ECDSA,
-			pem: `
------BEGIN EC PARAMETERS-----
-MGgCAQEEHBMUyVWFKTW4TwtwCmIAxdpsBFn0MV7tGeSA32CgBwYFK4EEACGhPAM6
-AATCkAx7whb2k3xWm+UjlFWFiV11oYmIdYgXqiAQkiz7fEq6QFhsjjCizeGzAlhT
-TmngRSxv/dSvGA==
------END EC PARAMETERS-----
-			`,
+			algo:    x509.ECDSA,
+			pem:     keyECDSA,
 			keyType: reflect.TypeOf(&ecdsa.PrivateKey{}),
 		},
 	}
 
-	for _, c := range testCases {
-		key := ParsePemEncodedKey(c.algo, []byte(c.pem))
-		if keyType := reflect.TypeOf(key); keyType != c.keyType {
-			t.Errorf("Unmatched key type: expected %v but got %v", c.keyType, keyType)
+	for id, c := range testCases {
+		key, err := ParsePemEncodedKey(c.algo, []byte(c.pem))
+		if c.errMsg != "" {
+			if err == nil {
+				t.Errorf("%s: no error is returned", id)
+			} else if c.errMsg != err.Error() {
+				t.Errorf(`%s: Unexpected error message: want "%s" but got "%s"`, id, c.errMsg, err.Error())
+			}
+		} else {
+			if keyType := reflect.TypeOf(key); keyType != c.keyType {
+				t.Errorf("%s: Unmatched key type: expected %v but got %v", id, c.keyType, keyType)
+			}
 		}
 	}
 }

--- a/pkg/pki/crypto_test.go
+++ b/pkg/pki/crypto_test.go
@@ -123,10 +123,8 @@ func TestParsePemEncodedCertificate(t *testing.T) {
 			} else if c.errMsg != err.Error() {
 				t.Errorf("%s: Unexpected error message: want %s but got %s", id, c.errMsg, err.Error())
 			}
-		} else {
-			if cert.PublicKeyAlgorithm != c.publicKeyAlgo {
-				t.Errorf("%s: Unexpected public key algorithm: want %d but got %d", id, c.publicKeyAlgo, cert.PublicKeyAlgorithm)
-			}
+		} else if cert.PublicKeyAlgorithm != c.publicKeyAlgo {
+			t.Errorf("%s: Unexpected public key algorithm: want %d but got %d", id, c.publicKeyAlgo, cert.PublicKeyAlgorithm)
 		}
 	}
 }
@@ -177,10 +175,8 @@ func TestParsePemEncodedKey(t *testing.T) {
 			} else if c.errMsg != err.Error() {
 				t.Errorf(`%s: Unexpected error message: want "%s" but got "%s"`, id, c.errMsg, err.Error())
 			}
-		} else {
-			if keyType := reflect.TypeOf(key); keyType != c.keyType {
-				t.Errorf("%s: Unmatched key type: expected %v but got %v", id, c.keyType, keyType)
-			}
+		} else if keyType := reflect.TypeOf(key); keyType != c.keyType {
+			t.Errorf("%s: Unmatched key type: expected %v but got %v", id, c.keyType, keyType)
 		}
 	}
 }


### PR DESCRIPTION
This allows caller to deal with errors directly and makes testing
easier.