### PR TITLE
Refactor: move /certmanager into /pkg

### DIFF
--- a/cmd/generate_cert/BUILD
+++ b/cmd/generate_cert/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
-        "//certmanager:go_default_library",
+        "//pkg/pki/ca:go_default_library",
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/cmd/generate_cert/main.go
+++ b/cmd/generate_cert/main.go
@@ -24,9 +24,9 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/golang/glog"
+	"istio.io/auth/pkg/pki/ca"
 
-	"istio.io/auth/certmanager"
+	"github.com/golang/glog"
 )
 
 // Layout for parsing time
@@ -82,11 +82,11 @@ func main() {
 	var signerCert *x509.Certificate
 	var signerPriv crypto.PrivateKey
 	if !*isSelfSigned {
-		signerCert, signerPriv = certmanager.LoadSignerCredsFromFiles(*signerCertFile, *signerPrivFile)
+		signerCert, signerPriv = ca.LoadSignerCredsFromFiles(*signerCertFile, *signerPrivFile)
 	}
 
 	nb := getNotBefore()
-	certPem, privPem := certmanager.GenCert(certmanager.CertOptions{
+	certPem, privPem := ca.GenCert(ca.CertOptions{
 		Host:         *host,
 		NotBefore:    getNotBefore(),
 		NotAfter:     nb.Add(*validFor),

--- a/cmd/generate_csr/BUILD
+++ b/cmd/generate_csr/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
-        "//certmanager:go_default_library",
+        "//pkg/pki/ca:go_default_library",
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/cmd/generate_csr/main.go
+++ b/cmd/generate_csr/main.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/golang/glog"
+	"istio.io/auth/pkg/pki/ca"
 
-	"istio.io/auth/certmanager"
+	"github.com/golang/glog"
 )
 
 var (
@@ -49,7 +49,7 @@ func saveCreds(csrPem []byte, privPem []byte) {
 func main() {
 	flag.Parse()
 
-	csrPem, privPem, err := certmanager.GenCSR(certmanager.CertOptions{
+	csrPem, privPem, err := ca.GenCSR(ca.CertOptions{
 		Host:       *host,
 		Org:        *org,
 		RSAKeySize: *keySize,

--- a/cmd/istio_ca/BUILD
+++ b/cmd/istio_ca/BUILD
@@ -5,9 +5,9 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
-        "//certmanager:go_default_library",
         "//cmd/istio_ca/version:go_default_library",
         "//controller:go_default_library",
+        "//pkg/pki/ca:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",

--- a/cmd/istio_ca/main.go
+++ b/cmd/istio_ca/main.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"time"
 
-	"istio.io/auth/certmanager"
 	"istio.io/auth/cmd/istio_ca/version"
 	"istio.io/auth/controller"
+	"istio.io/auth/pkg/pki/ca"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -130,25 +130,25 @@ func createClientset() *kubernetes.Clientset {
 	return cs
 }
 
-func createCA() certmanager.CertificateAuthority {
+func createCA() ca.CertificateAuthority {
 	if opts.selfSignedCA {
 		glog.Info("Use self-signed certificate as the CA certificate")
 
-		ca, err := certmanager.NewSelfSignedIstioCA(opts.caCertTTL, opts.certTTL, opts.selfSignedCAOrg)
+		ca, err := ca.NewSelfSignedIstioCA(opts.caCertTTL, opts.certTTL, opts.selfSignedCAOrg)
 		if err != nil {
 			glog.Fatalf("Failed to create a self-signed Istio CA (error: %v)", err)
 		}
 		return ca
 	}
 
-	caOpts := &certmanager.IstioCAOptions{
+	caOpts := &ca.IstioCAOptions{
 		CertChainBytes:   readFile(opts.certChainFile),
 		CertTTL:          opts.certTTL,
 		SigningCertBytes: readFile(opts.signingCertFile),
 		SigningKeyBytes:  readFile(opts.signingKeyFile),
 		RootCertBytes:    readFile(opts.rootCertFile),
 	}
-	ca, err := certmanager.NewIstioCA(caOpts)
+	ca, err := ca.NewIstioCA(caOpts)
 	if err != nil {
 		glog.Errorf("Failed to create an Istio CA (error %v)", err)
 	}

--- a/codecov.requirement
+++ b/codecov.requirement
@@ -1,4 +1,6 @@
 Requirements of code coverage percentage for packages
-Use this format: "Package name \t Required percentage"
-istio.io/auth/certmanager	80
-istio.io/auth/controller	65
+Use this format: "Package name     Required percentage"
+istio.io/auth/cmd/istio_ca/version  100
+istio.io/auth/controller            75
+istio.io/auth/pkg/pki              100
+istio.io/auth/pkg/pki/ca            80

--- a/controller/BUILD
+++ b/controller/BUILD
@@ -5,8 +5,8 @@ go_library(
     srcs = ["secret.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "//certmanager:go_default_library",
         "//pkg/pki:go_default_library",
+        "//pkg/pki/ca:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
@@ -25,7 +25,7 @@ go_test(
     srcs = ["secret_test.go"],
     library = ":go_default_library",
     deps = [
-        "//certmanager:go_default_library",
+        "//pkg/pki/ca:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_client_go//kubernetes/fake:go_default_library",

--- a/controller/secret.go
+++ b/controller/secret.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/golang/glog"
 
-	"istio.io/auth/certmanager"
 	"istio.io/auth/pkg/pki"
+	"istio.io/auth/pkg/pki/ca"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +54,7 @@ const (
 
 // SecretController manages the service accounts' secrets that contains Istio keys and certificates.
 type SecretController struct {
-	ca   certmanager.CertificateAuthority
+	ca   ca.CertificateAuthority
 	core corev1.CoreV1Interface
 
 	// Controller and store for service account objects.
@@ -67,7 +67,7 @@ type SecretController struct {
 }
 
 // NewSecretController returns a pointer to a newly constructed SecretController instance.
-func NewSecretController(ca certmanager.CertificateAuthority, core corev1.CoreV1Interface,
+func NewSecretController(ca ca.CertificateAuthority, core corev1.CoreV1Interface,
 	namespace string) *SecretController {
 
 	c := &SecretController{
@@ -236,7 +236,7 @@ func (sc *SecretController) scrtUpdated(oldObj, newObj interface{}) {
 
 	// Refresh the secret if 1) the certificate contained in the secret is about
 	// to expire, or 2) the root certificate in the secret is different than the
-	// one held by the certmanager (this may happen when the CA is restarted and
+	// one held by the ca (this may happen when the CA is restarted and
 	// a new self-signed CA cert is generated).
 	if ttl.Seconds() < secretResyncPeriod.Seconds() || !bytes.Equal(rootCertificate, scrt.Data[RootCertID]) {
 		namespace := scrt.GetNamespace()

--- a/controller/secret_test.go
+++ b/controller/secret_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/auth/certmanager"
+	"istio.io/auth/pkg/pki/ca"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -201,12 +201,12 @@ func TestUpdateSecret(t *testing.T) {
 			scrt.Data[RootCertID] = rc
 		}
 
-		opts := certmanager.CertOptions{
+		opts := ca.CertOptions{
 			IsSelfSigned: true,
 			NotAfter:     tc.notAfter,
 			RSAKeySize:   512,
 		}
-		bs, _ := certmanager.GenCert(opts)
+		bs, _ := ca.GenCert(opts)
 		scrt.Data[CertChainID] = bs
 
 		controller.scrtUpdated(nil, scrt)

--- a/node_agent/na/BUILD
+++ b/node_agent/na/BUILD
@@ -9,7 +9,7 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//certmanager:go_default_library",
+        "//pkg/pki/ca:go_default_library",
         "//proto:go_default_library",
         "//utils:go_default_library",
         "@com_github_golang_glog//:go_default_library",

--- a/node_agent/na/nodeagent.go
+++ b/node_agent/na/nodeagent.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"istio.io/auth/certmanager"
+	"istio.io/auth/pkg/pki/ca"
 	pb "istio.io/auth/proto"
 )
 
@@ -90,7 +90,7 @@ func (na nodeAgentInternal) Start() {
 }
 
 func (na *nodeAgentInternal) getCertificateSignRequest() ([]byte, *pb.CertificateSignRequest) {
-	csr, privKey, err := certmanager.GenCSR(certmanager.CertOptions{
+	csr, privKey, err := ca.GenCSR(ca.CertOptions{
 		Host:       *na.config.ServiceIdentity,
 		Org:        *na.config.ServiceIdentityOrg,
 		RSAKeySize: *na.config.RSAKeySize,

--- a/pkg/credential/BUILD
+++ b/pkg/credential/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["token.go"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_cloud_go//compute/metadata:go_default_library"],
+)

--- a/pkg/credential/token.go
+++ b/pkg/credential/token.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package certmanager
+package credential
 
 import (
 	"cloud.google.com/go/compute/metadata"

--- a/pkg/pki/ca/BUILD
+++ b/pkg/pki/ca/BUILD
@@ -5,13 +5,11 @@ go_library(
     srcs = [
         "ca.go",
         "generate_cert.go",
-        "util.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/pki:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@com_google_cloud_go//compute/metadata:go_default_library",
     ],
 )
 

--- a/pkg/pki/ca/ca.go
+++ b/pkg/pki/ca/ca.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package certmanager
+package ca
 
 import (
 	"crypto"

--- a/pkg/pki/ca/ca_test.go
+++ b/pkg/pki/ca/ca_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package certmanager
+package ca
 
 import (
 	"bytes"

--- a/pkg/pki/ca/generate_cert.go
+++ b/pkg/pki/ca/generate_cert.go
@@ -16,7 +16,7 @@
 // options. This implementation is Largely inspired from
 // https://golang.org/src/crypto/tls/generate_cert.go.
 
-package certmanager
+package ca
 
 import (
 	"crypto"

--- a/pkg/pki/ca/generate_cert_test.go
+++ b/pkg/pki/ca/generate_cert_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package certmanager
+package ca
 
 import (
 	"crypto/x509"


### PR DESCRIPTION
Specifically, CA related methods are moved into /pkg/pki/ca; GCP token
fetcher is moved into /pkg/credential/