### PR TITLE
Remove unnecessary rules in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,10 +18,6 @@ load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_repositories")
 
 proto_repositories()
 
-load("@org_pubref_rules_protobuf//gogo:rules.bzl", "gogo_proto_repositories")
-
-gogo_proto_repositories()
-
 go_repository(
     name = "com_google_cloud_go",
     commit = "2e6a95edb1071d750f6d7db777bf66cd2997af6c",  # Mar 9, 2017 (v0.7.0)


### PR DESCRIPTION
This is not used and is the source of the annoying warning about switch
from `new_go_repository` to `go_repository`.