### PR TITLE
Add OWNERS and pr template for mungegithub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+**Release note**:
+<!--  Steps to write your release note:
+1. Use the release-note-* labels to set the release note state (if you have access)
+2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
+-->
+```release-note
+```

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,10 @@
 reviewers:
   - lookuptable
   - wattli
+  - myidpt
+  - wenchenglu
 approvers:
   - lookuptable
   - wattli
+  - myidpt
+  - wenchenglu

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - lookuptable
+  - wattli
+approvers:
+  - lookuptable
+  - wattli


### PR DESCRIPTION
Add required files for Mungegithub.

OWNERS file defines who can approve prs in this repo and who are recommended reviewer.
PR template helps people add release-note when creating prs. Simply add release-note or "NONE" between ```, then mungegithub will add proper release-note label. More details at https://github.com/istio/istio/pull/525

More details about [Mungegithub](https://github.com/istio/test-infra/tree/master/mungegithub/deployment)

[Related pr](https://github.com/istio/mixer/pull/1024)