### PR TITLE
Run GRPC server over TLS

### DIFF
--- a/cmd/istio_ca/main.go
+++ b/cmd/istio_ca/main.go
@@ -55,7 +55,8 @@ type cliOptions struct {
 	caCertTTL time.Duration
 	certTTL   time.Duration
 
-	grpcPort int
+	grpcHostname string
+	grpcPort     int
 }
 
 var (
@@ -93,6 +94,7 @@ func init() {
 		"The TTL of self-signed CA root certificate (default to 10 days)")
 	flags.DurationVar(&opts.certTTL, "cert-ttl", time.Hour, "The TTL of issued certificates (default to 1 hour)")
 
+	flags.StringVar(&opts.grpcHostname, "grpc-hostname", "localhost", "Specifies the hostname for GRPC server.")
 	flags.IntVar(&opts.grpcPort, "grpc-port", 0, "Specifies the port number for GRPC server. "+
 		"If unspecified, Istio CA will not server GRPC request.")
 
@@ -124,7 +126,7 @@ func runCA() {
 	sc.Run(stopCh)
 
 	if opts.grpcPort > 0 {
-		grpcServer := grpc.New(ca, opts.grpcPort)
+		grpcServer := grpc.New(ca, opts.grpcHostname, opts.grpcPort)
 		if err := grpcServer.Run(); err != nil {
 			glog.Warningf("Failed to start GRPC server with error: %v", err)
 		}

--- a/pkg/pki/ca/ca_test.go
+++ b/pkg/pki/ca/ca_test.go
@@ -202,17 +202,13 @@ func TestSignCSR(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	csr, err := pki.ParsePemEncodedCSR(csrPEM)
-	if err != nil {
-		t.Error(err)
-	}
 
 	ca, err := NewSelfSignedIstioCA(24*time.Hour, time.Hour, "istio.io")
 	if err != nil {
 		t.Error(err)
 	}
 
-	certPEM, err := ca.Sign(csr)
+	certPEM, err := ca.Sign(csrPEM)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/pki/ca/controller/secret_test.go
+++ b/pkg/pki/ca/controller/secret_test.go
@@ -15,7 +15,6 @@
 package controller
 
 import (
-	"crypto/x509"
 	"reflect"
 	"testing"
 	"time"
@@ -31,7 +30,7 @@ import (
 
 type fakeCa struct{}
 
-func (ca *fakeCa) Sign(*x509.CertificateRequest) ([]byte, error) {
+func (ca *fakeCa) Sign([]byte) ([]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/server/grpc/BUILD
+++ b/pkg/server/grpc/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ],
 )

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -15,16 +15,18 @@
 package grpc
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/golang/glog"
 
 	"golang.org/x/net/context"
 
-	"istio.io/auth/pkg/pki"
 	"istio.io/auth/pkg/pki/ca"
 	pb "istio.io/auth/proto"
 )
@@ -32,8 +34,10 @@ import (
 // Server implements pb.IstioCAService and provides the service on the
 // specified port.
 type Server struct {
-	ca   ca.CertificateAuthority
-	port int
+	ca          ca.CertificateAuthority
+	certificate *tls.Certificate
+	hostname    string
+	port        int
 }
 
 // HandleCSR handles an incoming certificate signing request (CSR). It does
@@ -43,14 +47,7 @@ type Server struct {
 func (s *Server) HandleCSR(ctx context.Context, request *pb.Request) (*pb.Response, error) {
 	// TODO: handle authentication here
 
-	csr, err := pki.ParsePemEncodedCSR(request.CsrPem)
-	if err != nil {
-		glog.Error(err)
-		// TODO: possibly wrap err in GRPC error
-		return nil, err
-	}
-
-	cert, err := s.ca.Sign(csr)
+	cert, err := s.ca.Sign(request.CsrPem)
 	if err != nil {
 		glog.Error(err)
 		// TODO: possibly wrap err in GRPC error
@@ -71,7 +68,10 @@ func (s *Server) Run() error {
 	if err != nil {
 		return fmt.Errorf("cannot listen on port %d (error: %v)", s.port, err)
 	}
-	grpcServer := grpc.NewServer()
+
+	serverOption := s.createTLSServerOption()
+
+	grpcServer := grpc.NewServer(serverOption)
 	pb.RegisterIstioCAServiceServer(grpcServer, s)
 
 	// grpcServer.Serve() is a blocking call, so run it in a goroutine.
@@ -88,6 +88,59 @@ func (s *Server) Run() error {
 }
 
 // New creates a new instance of `IstioCAServiceServer`.
-func New(ca ca.CertificateAuthority, port int) *Server {
-	return &Server{ca, port}
+func New(ca ca.CertificateAuthority, hostname string, port int) *Server {
+	return &Server{
+		ca:       ca,
+		hostname: hostname,
+		port:     port,
+	}
+}
+
+func (s *Server) createTLSServerOption() grpc.ServerOption {
+	config := &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			if s.certificate == nil || !isValid(s.certificate) {
+				// apply new certificate if there isn't one yet, or the one has become invalid
+				newCert, err := s.applyServerCertificate()
+				if err != nil {
+					return nil, err
+				}
+				s.certificate = newCert
+			}
+			return s.certificate, nil
+		},
+	}
+	return grpc.Creds(credentials.NewTLS(config))
+}
+
+func (s *Server) applyServerCertificate() (*tls.Certificate, error) {
+	opts := ca.CertOptions{
+		Host:       s.hostname,
+		RSAKeySize: 1024,
+	}
+
+	csrPEM, privPEM, err := ca.GenCSR(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM, err := s.ca.Sign(csrPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, privPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &cert, nil
+}
+
+func isValid(cert *tls.Certificate) bool {
+	leaf := cert.Leaf
+	if leaf == nil {
+		return false
+	}
+	now := time.Now()
+	return leaf.NotBefore.Before(now) && leaf.NotAfter.After(now)
 }

--- a/pkg/server/grpc/server_test.go
+++ b/pkg/server/grpc/server_test.go
@@ -119,11 +119,20 @@ func TestIsValid(t *testing.T) {
 			},
 			expected: false,
 		},
+		"Cert is invalid when it is about to expire": {
+			cert: &tls.Certificate{
+				Leaf: &x509.Certificate{
+					NotAfter:  now.Add(5 * time.Second),
+					NotBefore: now.Add(-time.Minute),
+				},
+			},
+			expected: false,
+		},
 		"Cert is valid": {
 			cert: &tls.Certificate{
 				Leaf: &x509.Certificate{
-					NotAfter:  now.Add(time.Minute),
-					NotBefore: now.Add(-time.Minute),
+					NotAfter:  now.Add(5 * time.Minute),
+					NotBefore: now.Add(-5 * time.Minute),
 				},
 			},
 			expected: true,

--- a/pkg/server/grpc/server_test.go
+++ b/pkg/server/grpc/server_test.go
@@ -16,9 +16,11 @@ package grpc
 
 import (
 	"bytes"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"testing"
+	"time"
 
 	"istio.io/auth/pkg/pki/ca"
 	pb "istio.io/auth/proto"
@@ -42,7 +44,7 @@ type mockCA struct {
 	errMsg string
 }
 
-func (ca *mockCA) Sign(csr *x509.CertificateRequest) ([]byte, error) {
+func (ca *mockCA) Sign(csrPEM []byte) ([]byte, error) {
 	if ca.errMsg != "" {
 		return nil, fmt.Errorf(ca.errMsg)
 	}
@@ -64,10 +66,6 @@ func TestSign(t *testing.T) {
 		cert   string
 		errMsg string
 	}{
-		"Bad CSR string": {
-			csr:    "bad CSR string",
-			errMsg: "Certificate signing request is not properly encoded",
-		},
 		"Failed to sign": {
 			ca:     &mockCA{errMsg: "cannot sign"},
 			csr:    csr,
@@ -81,7 +79,7 @@ func TestSign(t *testing.T) {
 	}
 
 	for id, c := range testCases {
-		server := New(c.ca, 8080)
+		server := New(c.ca, "hostname", 8080)
 		request := &pb.Request{CsrPem: []byte(c.csr)}
 
 		response, err := server.HandleCSR(nil, request)
@@ -89,6 +87,53 @@ func TestSign(t *testing.T) {
 			t.Errorf("Case %s: expecting error message (%s) but got (%s)", id, c.errMsg, err.Error())
 		} else if c.errMsg == "" && !bytes.Equal(response.SignedCertChain, []byte(c.cert)) {
 			t.Errorf("Case %s: expecting cert to be (%s) but got (%s)", id, c.cert, response.SignedCertChain)
+		}
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	now := time.Now()
+	testCases := map[string]struct {
+		cert     *tls.Certificate
+		expected bool
+	}{
+		"No leaf cert": {
+			cert:     &tls.Certificate{},
+			expected: false,
+		},
+		"Cert is not valid yet": {
+			cert: &tls.Certificate{
+				Leaf: &x509.Certificate{
+					NotAfter:  now.Add(5 * time.Minute),
+					NotBefore: now.Add(time.Minute),
+				},
+			},
+			expected: false,
+		},
+		"Cert is expired": {
+			cert: &tls.Certificate{
+				Leaf: &x509.Certificate{
+					NotAfter:  now.Add(-time.Minute),
+					NotBefore: now.Add(-5 * time.Minute),
+				},
+			},
+			expected: false,
+		},
+		"Cert is valid": {
+			cert: &tls.Certificate{
+				Leaf: &x509.Certificate{
+					NotAfter:  now.Add(time.Minute),
+					NotBefore: now.Add(-time.Minute),
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for id, tc := range testCases {
+		result := isValid(tc.cert)
+		if tc.expected != result {
+			t.Errorf("%s: expected result is %t but got %t", id, tc.expected, result)
 		}
 	}
 }


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
GRPC service is now served over TLS
```
