### PR TITLE
[WIP] Add a GRPC authenticator for client certificate

### DIFF
--- a/pkg/pki/BUILD
+++ b/pkg/pki/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["crypto.go"],
+    srcs = [
+        "crypto.go",
+        "pkix.go",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/pki/ca/ca_test.go
+++ b/pkg/pki/ca/ca_test.go
@@ -77,7 +77,7 @@ func TestSelfSignedIstioCA(t *testing.T) {
 
 	foundSAN := false
 	for _, ee := range cert.Extensions {
-		if ee.Id.Equal(oidSubjectAltName) {
+		if ee.Id.Equal(pki.OIDSubjectAltName) {
 			foundSAN = true
 			id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, name)
 			rv := asn1.RawValue{Tag: tagURI, Class: asn1.ClassContextSpecific, Bytes: []byte(id)}
@@ -219,18 +219,8 @@ func TestSignCSR(t *testing.T) {
 	}
 
 	expected := []pkix.Extension{buildSubjectAltNameExtension(host)}
-	actual := extractSANExtensions(cert.Extensions)
+	actual := pki.ExtractSANExtensions(cert.Extensions)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Unexpected extensions: wanted %v but got %v", expected, actual)
 	}
-}
-
-func extractSANExtensions(exts []pkix.Extension) []pkix.Extension {
-	sans := []pkix.Extension{}
-	for _, ext := range exts {
-		if ext.Id.Equal(oidSubjectAltName) {
-			sans = append(sans, ext)
-		}
-	}
-	return sans
 }

--- a/pkg/pki/ca/generate_cert.go
+++ b/pkg/pki/ca/generate_cert.go
@@ -82,9 +82,6 @@ const (
 	uriScheme = "spiffe"
 )
 
-// See http://www.alvestrand.no/objectid/2.5.29.17.html.
-var oidSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
-
 // GenCSR generates a X.509 certificate sign request and private key with the given options.
 func GenCSR(options CertOptions) ([]byte, []byte, error) {
 	// Generates a CSR
@@ -260,5 +257,5 @@ func buildSubjectAltNameExtension(host string) pkix.Extension {
 		glog.Fatalf("Failed to marshal the raw values for SAN field (err: %s)", err)
 	}
 
-	return pkix.Extension{Id: oidSubjectAltName, Value: bs}
+	return pkix.Extension{Id: pki.OIDSubjectAltName, Value: bs}
 }

--- a/pkg/pki/pkix.go
+++ b/pkg/pki/pkix.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pki
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+)
+
+// OIDSubjectAltName is the OID for Subject Alternative Name.
+// See http://www.alvestrand.no/objectid/2.5.29.17.html.
+var OIDSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
+
+// ExtractSANExtensions returns a list of SAN extensions from a given set of
+// pkix.Extension.
+func ExtractSANExtensions(exts []pkix.Extension) []pkix.Extension {
+	sans := []pkix.Extension{}
+	for _, ext := range exts {
+		if ext.Id.Equal(OIDSubjectAltName) {
+			sans = append(sans, ext)
+		}
+	}
+	return sans
+}

--- a/pkg/server/grpc/BUILD
+++ b/pkg/server/grpc/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["server.go"],
+    srcs = [
+        "authenticator.go",
+        "server.go",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/pki:go_default_library",
@@ -11,6 +14,7 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//peer:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ],
 )

--- a/pkg/server/grpc/authenticator.go
+++ b/pkg/server/grpc/authenticator.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"crypto/x509"
+
+	"istio.io/auth/pkg/pki"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+type user struct {
+	identities []string
+}
+
+type authenticator interface {
+	authenticate(ctx context.Context) (*user, bool)
+}
+
+// A authenticator that extracts identities from client certificate.
+type clientCertAuthenticator struct{}
+
+// authenticate extracts identities from presented client certificates. This
+// method assumes that certificate chain has been properly validated before
+// this method is called. In other words, this method does not do chain
+// validation itself.
+func (cca *clientCertAuthenticator) authenticate(ctx context.Context) (*user, bool) {
+	peer, ok := peer.FromContext(ctx)
+	if !ok {
+		glog.Info("no client certificate is presented")
+		return nil, false
+	}
+
+	if authType := peer.AuthInfo.AuthType(); authType != "tls" {
+		glog.Warningf("unsupported auth type: %q", authType)
+		return nil, false
+	}
+
+	tlsInfo := peer.AuthInfo.(credentials.TLSInfo)
+	chains := tlsInfo.State.VerifiedChains
+	if len(chains) == 0 || len(chains[0]) == 0 {
+		glog.Warningf("no verified chain is found")
+		return nil, false
+	}
+
+	ids := extractIDs(chains[0][0])
+	return &user{ids}, true
+}
+
+func extractIDs(certificate *x509.Certificate) []string {
+	ids := []string{}
+	sans := pki.ExtractSANExtensions(certificate.Extensions)
+	for _, san := range sans {
+		ids = append(ids, string(san.Value))
+	}
+	return ids
+}


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add an authenticator for GRPC server that extracts client identity from presented peer certificate.
```
