### PR TITLE
Add a method to extract identities from SAN extension

### DIFF
--- a/pkg/pki/BUILD
+++ b/pkg/pki/BUILD
@@ -2,12 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["crypto.go"],
+    srcs = [
+        "crypto.go",
+        "san.go",
+    ],
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["crypto_test.go"],
+    srcs = [
+        "crypto_test.go",
+        "san_test.go",
+    ],
     library = ":go_default_library",
 )

--- a/pkg/pki/ca/ca_test.go
+++ b/pkg/pki/ca/ca_test.go
@@ -17,7 +17,6 @@ package ca
 import (
 	"bytes"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
 	"reflect"
@@ -75,24 +74,20 @@ func TestSelfSignedIstioCA(t *testing.T) {
 		t.Error("Failed to verify generated cert")
 	}
 
-	foundSAN := false
-	for _, ee := range cert.Extensions {
-		if ee.Id.Equal(oidSubjectAltName) {
-			foundSAN = true
-			id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, name)
-			rv := asn1.RawValue{Tag: tagURI, Class: asn1.ClassContextSpecific, Bytes: []byte(id)}
-			bs, err := asn1.Marshal([]asn1.RawValue{rv})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !bytes.Equal(bs, ee.Value) {
-				t.Errorf("SAN field does not match: %s is expected but actual is %s", bs, ee.Value)
-			}
-		}
-	}
-	if !foundSAN {
+	san, found := pki.ExtractSANExtension(cert)
+	if !found {
 		t.Errorf("Generated certificate does not contain a SAN field")
+	}
+
+	id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, name)
+	rv := asn1.RawValue{Tag: 6, Class: asn1.ClassContextSpecific, Bytes: []byte(id)}
+	bs, err := asn1.Marshal([]asn1.RawValue{rv})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !bytes.Equal(bs, san.Value) {
+		t.Errorf("SAN field does not match: %s is expected but actual is %s", bs, san.Value)
 	}
 }
 
@@ -218,19 +213,12 @@ func TestSignCSR(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := []pkix.Extension{buildSubjectAltNameExtension(host)}
-	actual := extractSANExtensions(cert.Extensions)
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Unexpected extensions: wanted %v but got %v", expected, actual)
+	san, found := pki.ExtractSANExtension(cert)
+	if !found {
+		t.Errorf("No SAN extension is found in the certificate")
 	}
-}
-
-func extractSANExtensions(exts []pkix.Extension) []pkix.Extension {
-	sans := []pkix.Extension{}
-	for _, ext := range exts {
-		if ext.Id.Equal(oidSubjectAltName) {
-			sans = append(sans, ext)
-		}
+	expected := buildSubjectAltNameExtension(host)
+	if !reflect.DeepEqual(expected, san) {
+		t.Errorf("Unexpected extensions: wanted %v but got %v", expected, san)
 	}
-	return sans
 }

--- a/pkg/pki/ca/ca_test.go
+++ b/pkg/pki/ca/ca_test.go
@@ -74,8 +74,8 @@ func TestSelfSignedIstioCA(t *testing.T) {
 		t.Error("Failed to verify generated cert")
 	}
 
-	san, found := pki.ExtractSANExtension(cert)
-	if !found {
+	san := pki.ExtractSANExtension(cert)
+	if san == nil {
 		t.Errorf("Generated certificate does not contain a SAN field")
 	}
 
@@ -213,8 +213,8 @@ func TestSignCSR(t *testing.T) {
 		t.Error(err)
 	}
 
-	san, found := pki.ExtractSANExtension(cert)
-	if !found {
+	san := pki.ExtractSANExtension(cert)
+	if san == nil {
 		t.Errorf("No SAN extension is found in the certificate")
 	}
 	expected := buildSubjectAltNameExtension(host)

--- a/pkg/pki/san.go
+++ b/pkg/pki/san.go
@@ -1,0 +1,153 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pki
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+)
+
+// IdentityType represents type of an identity. This is used to properly encode
+// an identity into a SAN extension.
+type IdentityType int
+
+const (
+	// TypeDNS represents a DNS name.
+	TypeDNS IdentityType = iota
+	// TypeIP represents an IP address.
+	TypeIP
+	// TypeURI represents a universal resource identifier.
+	TypeURI
+)
+
+var (
+	// Mapping from the type of an identity to the OID tag value for the X.509
+	// SAN field (see https://tools.ietf.org/html/rfc5280#appendix-A.2)
+	//
+	// SubjectAltName ::= GeneralNames
+	//
+	// GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+	//
+	// GeneralName ::= CHOICE {
+	//      dNSName                         [2]     IA5String,
+	//      uniformResourceIdentifier       [6]     IA5String,
+	//      iPAddress                       [7]     OCTET STRING,
+	// }
+	oidTagMap = map[IdentityType]int{
+		TypeDNS: 2,
+		TypeURI: 6,
+		TypeIP:  7,
+	}
+
+	// A reversed map that maps from an OID tag to the corresponding identity
+	// type.
+	identityTypeMap = generateReversedMap(oidTagMap)
+
+	// The OID for the SAN extension (See
+	// http://www.alvestrand.no/objectid/2.5.29.17.html).
+	oidSubjectAlternativeName = asn1.ObjectIdentifier{2, 5, 29, 17}
+)
+
+// Identity is an object holding both the encoded identifier bytes as well as
+// the type of the identity.
+type Identity struct {
+	Type  IdentityType
+	Value []byte
+}
+
+// BuildSANExtension builds a `pkix.Extension` of type "Subject
+// Alternative Name" based on the given identities.
+func BuildSANExtension(identites []Identity) (*pkix.Extension, error) {
+	rawValues := []asn1.RawValue{}
+	for _, i := range identites {
+		tag, ok := oidTagMap[i.Type]
+		if !ok {
+			return nil, fmt.Errorf("unsupported identity type: %v", i.Type)
+		}
+
+		rawValues = append(rawValues, asn1.RawValue{
+			Bytes: i.Value,
+			Class: asn1.ClassContextSpecific,
+			Tag:   tag,
+		})
+	}
+
+	bs, err := asn1.Marshal(rawValues)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal the raw values for SAN field (err: %s)", err)
+	}
+
+	return &pkix.Extension{Id: oidSubjectAlternativeName, Value: bs}, nil
+}
+
+// ExtractIDsFromSAN takes a SAN extension and extracts the identities.
+// The logic is mostly borrowed from
+// https://github.com/golang/go/blob/master/src/crypto/x509/x509.go, with the
+// addition of supporting extracting URIs.
+func ExtractIDsFromSAN(sanExt *pkix.Extension) ([]Identity, error) {
+	if !sanExt.Id.Equal(oidSubjectAlternativeName) {
+		return nil, fmt.Errorf("The input is not a SAN extension")
+	}
+
+	var sequence asn1.RawValue
+	if rest, err := asn1.Unmarshal(sanExt.Value, &sequence); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, fmt.Errorf("The SAN extension is incorrectly encoded")
+	}
+
+	// Check the rawValue is a sequence.
+	if !sequence.IsCompound || sequence.Tag != asn1.TagSequence || sequence.Class != asn1.ClassUniversal {
+		return nil, fmt.Errorf("The SAN extension is incorrectly encoded")
+	}
+
+	ids := []Identity{}
+	for bytes := sequence.Bytes; len(bytes) > 0; {
+		var rawValue asn1.RawValue
+		var err error
+
+		bytes, err = asn1.Unmarshal(bytes, &rawValue)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, Identity{Type: identityTypeMap[rawValue.Tag], Value: rawValue.Bytes})
+	}
+
+	return ids, nil
+}
+
+// ExtractSANExtension extracts the "Subject Alternative Name" externsion from
+// the given X.509 cerificate.
+func ExtractSANExtension(cert *x509.Certificate) (*pkix.Extension, bool) {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oidSubjectAlternativeName) {
+			// We don't need to examine other extensions anymore since a certificate
+			// must not include more than one instance of a particular extension. See
+			// https://tools.ietf.org/html/rfc5280#section-4.2.
+			return &ext, true
+		}
+	}
+	return nil, false
+}
+
+func generateReversedMap(m map[IdentityType]int) map[int]IdentityType {
+	reversed := make(map[int]IdentityType)
+	for key, value := range m {
+		reversed[value] = key
+	}
+	return reversed
+}

--- a/pkg/pki/san.go
+++ b/pkg/pki/san.go
@@ -132,16 +132,16 @@ func ExtractIDsFromSAN(sanExt *pkix.Extension) ([]Identity, error) {
 
 // ExtractSANExtension extracts the "Subject Alternative Name" externsion from
 // the given X.509 cerificate.
-func ExtractSANExtension(cert *x509.Certificate) (*pkix.Extension, bool) {
+func ExtractSANExtension(cert *x509.Certificate) *pkix.Extension {
 	for _, ext := range cert.Extensions {
 		if ext.Id.Equal(oidSubjectAlternativeName) {
 			// We don't need to examine other extensions anymore since a certificate
 			// must not include more than one instance of a particular extension. See
 			// https://tools.ietf.org/html/rfc5280#section-4.2.
-			return &ext, true
+			return &ext
 		}
 	}
-	return nil, false
+	return nil
 }
 
 func generateReversedMap(m map[IdentityType]int) map[int]IdentityType {

--- a/pkg/pki/san_test.go
+++ b/pkg/pki/san_test.go
@@ -1,0 +1,120 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pki
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"reflect"
+	"testing"
+)
+
+func TestBuildAndExtractIdentities(t *testing.T) {
+	ids := []Identity{
+		Identity{Type: TypeDNS, Value: []byte("test.domain.com")},
+		Identity{Type: TypeIP, Value: []byte("10.0.0.1")},
+		Identity{Type: TypeURI, Value: []byte("spiffe://test.domain.com/ns/default/sa/default")},
+	}
+	san, err := BuildSANExtension(ids)
+	if err != nil {
+		t.Errorf("A unexpected error has been encountered (error: %v)", err)
+	}
+
+	actualIds, err := ExtractIDsFromSAN(san)
+	if err != nil {
+		t.Errorf("A unexpected error has been encountered (error: %v)", err)
+	}
+
+	if !reflect.DeepEqual(actualIds, ids) {
+		t.Errorf("Unmatched identities: before encoding: %v, after decoding %v", ids, actualIds)
+	}
+}
+
+func TestBuildSANExtensionWithError(t *testing.T) {
+	id := Identity{Type: 10}
+	if _, err := BuildSANExtension([]Identity{id}); err == nil {
+		t.Error("Expecting error to be returned by got nil")
+	}
+}
+
+func TestExtractIDsFromSANWithError(t *testing.T) {
+	testCases := map[string]struct {
+		ext *pkix.Extension
+	}{
+		"Wrong OID": {
+			ext: &pkix.Extension{
+				Id: asn1.ObjectIdentifier{1, 2, 3},
+			},
+		},
+		"Wrong encoding": {
+			ext: &pkix.Extension{
+				Id:    oidSubjectAlternativeName,
+				Value: []byte("bad value"),
+			},
+		},
+	}
+
+	for id, tc := range testCases {
+		if _, err := ExtractIDsFromSAN(tc.ext); err == nil {
+			t.Errorf("%v: Expecting error to be returned by got nil", id)
+		}
+	}
+}
+
+func TestExtractIDsFromSANWithBadEncoding(t *testing.T) {
+	ext := &pkix.Extension{
+		Id:    oidSubjectAlternativeName,
+		Value: []byte("bad value"),
+	}
+
+	if _, err := ExtractIDsFromSAN(ext); err == nil {
+		t.Error("Expecting error to be returned by got nil")
+	}
+}
+
+func TestExtractSANExtension(t *testing.T) {
+	testCases := map[string]struct {
+		exts  []pkix.Extension
+		found bool
+	}{
+		"No extension": {
+			exts:  []pkix.Extension{},
+			found: false,
+		},
+		"An extensions with wrong OID": {
+			exts: []pkix.Extension{
+				pkix.Extension{Id: asn1.ObjectIdentifier{1, 2, 3}},
+			},
+			found: false,
+		},
+		"Correct SAN extension": {
+			exts: []pkix.Extension{
+				pkix.Extension{Id: asn1.ObjectIdentifier{1, 2, 3}},
+				pkix.Extension{Id: asn1.ObjectIdentifier{2, 5, 29, 17}},
+				pkix.Extension{Id: asn1.ObjectIdentifier{3, 2, 1}},
+			},
+			found: true,
+		},
+	}
+
+	for id, tc := range testCases {
+		cert := &x509.Certificate{Extensions: tc.exts}
+		_, found := ExtractSANExtension(cert)
+		if found != tc.found {
+			t.Errorf("Case %q: expect `found` to be %t but got %t", id, tc.found, found)
+		}
+	}
+}

--- a/pkg/pki/san_test.go
+++ b/pkg/pki/san_test.go
@@ -112,7 +112,7 @@ func TestExtractSANExtension(t *testing.T) {
 
 	for id, tc := range testCases {
 		cert := &x509.Certificate{Extensions: tc.exts}
-		_, found := ExtractSANExtension(cert)
+		found := ExtractSANExtension(cert) != nil
 		if found != tc.found {
 			t.Errorf("Case %q: expect `found` to be %t but got %t", id, tc.found, found)
 		}

--- a/pkg/pki/san_test.go
+++ b/pkg/pki/san_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestBuildAndExtractIdentities(t *testing.T) {
 	ids := []Identity{
-		Identity{Type: TypeDNS, Value: []byte("test.domain.com")},
-		Identity{Type: TypeIP, Value: []byte("10.0.0.1")},
-		Identity{Type: TypeURI, Value: []byte("spiffe://test.domain.com/ns/default/sa/default")},
+		{Type: TypeDNS, Value: []byte("test.domain.com")},
+		{Type: TypeIP, Value: []byte("10.0.0.1")},
+		{Type: TypeURI, Value: []byte("spiffe://test.domain.com/ns/default/sa/default")},
 	}
 	san, err := BuildSANExtension(ids)
 	if err != nil {
@@ -96,15 +96,15 @@ func TestExtractSANExtension(t *testing.T) {
 		},
 		"An extensions with wrong OID": {
 			exts: []pkix.Extension{
-				pkix.Extension{Id: asn1.ObjectIdentifier{1, 2, 3}},
+				{Id: asn1.ObjectIdentifier{1, 2, 3}},
 			},
 			found: false,
 		},
 		"Correct SAN extension": {
 			exts: []pkix.Extension{
-				pkix.Extension{Id: asn1.ObjectIdentifier{1, 2, 3}},
-				pkix.Extension{Id: asn1.ObjectIdentifier{2, 5, 29, 17}},
-				pkix.Extension{Id: asn1.ObjectIdentifier{3, 2, 1}},
+				{Id: asn1.ObjectIdentifier{1, 2, 3}},
+				{Id: asn1.ObjectIdentifier{2, 5, 29, 17}},
+				{Id: asn1.ObjectIdentifier{3, 2, 1}},
 			},
 			found: true,
 		},


### PR DESCRIPTION
This will be used by the grpc server for client certificate based
authN/authZ.

Also grouping all SAN-related operations into package `pkg/pki/san.go`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
