### PR TITLE
Extend default CA root cert TTL to 1 year

### DIFF
--- a/cmd/istio_ca/main.go
+++ b/cmd/istio_ca/main.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	defaultCACertTTL = 365 * 24 * time.Hour
+
 	// The default issuer organization for self-signed CA certificate.
 	selfSignedCAOrgDefault = "k8s.cluster.local"
 
@@ -90,9 +92,9 @@ func init() {
 		fmt.Sprintf("The issuer organization used in self-signed CA certificate (default to %s)",
 			selfSignedCAOrgDefault))
 
-	flags.DurationVar(&opts.caCertTTL, "ca-cert-ttl", 240*time.Hour,
-		"The TTL of self-signed CA root certificate (default to 10 days)")
-	flags.DurationVar(&opts.certTTL, "cert-ttl", time.Hour, "The TTL of issued certificates (default to 1 hour)")
+	flags.DurationVar(&opts.caCertTTL, "ca-cert-ttl", defaultCACertTTL,
+		"The TTL of self-signed CA root certificate")
+	flags.DurationVar(&opts.certTTL, "cert-ttl", time.Hour, "The TTL of issued certificates")
 
 	flags.StringVar(&opts.grpcHostname, "grpc-hostname", "localhost", "Specifies the hostname for GRPC server.")
 	flags.IntVar(&opts.grpcPort, "grpc-port", 0, "Specifies the port number for GRPC server. "+


### PR DESCRIPTION
/assign @wattli
/cc @rshriram

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
The default self-signed CA root cert TTL is extended to be 1 year
```
