### PR TITLE
Set flag.Parsed() to be true and carry over glog flags

### DIFF
--- a/cmd/istio_ca/BUILD
+++ b/cmd/istio_ca/BUILD
@@ -6,6 +6,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//cmd/istio_ca/version:go_default_library",
+        "//pkg/cmd:go_default_library",
         "//pkg/pki/ca:go_default_library",
         "//pkg/pki/ca/controller:go_default_library",
         "//pkg/server/grpc:go_default_library",

--- a/cmd/istio_ca/main.go
+++ b/cmd/istio_ca/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"istio.io/auth/cmd/istio_ca/version"
+	"istio.io/auth/pkg/cmd"
 	"istio.io/auth/pkg/pki/ca"
 	"istio.io/auth/pkg/pki/ca/controller"
 	"istio.io/auth/pkg/server/grpc"
@@ -101,6 +102,8 @@ func init() {
 		"If unspecified, Istio CA will not server GRPC request.")
 
 	rootCmd.AddCommand(version.Command)
+
+	cmd.InitializeFlags(rootCmd)
 }
 
 func main() {

--- a/cmd/node_agent/BUILD
+++ b/cmd/node_agent/BUILD
@@ -6,6 +6,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/node_agent/na:go_default_library",
+        "//pkg/cmd:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],

--- a/cmd/node_agent/main.go
+++ b/cmd/node_agent/main.go
@@ -17,9 +17,11 @@ package main
 import (
 	"os"
 
+	"istio.io/auth/cmd/node_agent/na"
+	"istio.io/auth/pkg/cmd"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"istio.io/auth/cmd/node_agent/na"
 )
 
 var (
@@ -44,6 +46,8 @@ func init() {
 	flags.StringVar(&naConfig.ServiceIdentityDir, "cert-dir", "./", "Certificate directory")
 	flags.StringVar(&naConfig.RootCACertFile, "root-cert", "", "Root Certificate file")
 	flags.IntVar(&naConfig.Env, "env", na.ONPREM, "Node Environment : onprem | gcp")
+
+	cmd.InitializeFlags(rootCmd)
 }
 
 func main() {

--- a/integration/BUILD
+++ b/integration/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/cmd:go_default_library",
         "//pkg/pki/ca/controller:go_default_library",
         "//pkg/pki/testutil:go_default_library",
         "@com_github_golang_glog//:go_default_library",

--- a/integration/main.go
+++ b/integration/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"istio.io/auth/pkg/cmd"
 	"istio.io/auth/pkg/pki/ca/controller"
 	"istio.io/auth/pkg/pki/testutil"
 
@@ -62,7 +63,7 @@ func init() {
 	flags.StringVar(&opts.containerTag, "tag", "", "Tag for Istio CA image")
 	flags.StringVarP(&opts.kubeconfig, "kube-config", "k", "~/.kube/config", "path to kubeconfig file")
 
-	addFlags(rootCmd)
+	cmd.InitializeFlags(rootCmd)
 }
 
 func main() {
@@ -246,20 +247,4 @@ func waitForSecretExist(secretName string, timeToWait time.Duration) (*v1.Secret
 			return nil, fmt.Errorf("secret %v/%v did not become existent within %v", opts.namespace, secretName, timeToWait)
 		}
 	}
-}
-
-// addFlags carries over glog flags with new defaults
-func addFlags(rootCmd *cobra.Command) {
-	flag.CommandLine.VisitAll(func(gf *flag.Flag) {
-		switch gf.Name {
-		case "logtostderr":
-			if err := gf.Value.Set("true"); err != nil {
-				fmt.Printf("missing logtostderr flag: %v", err)
-			}
-		case "log_dir", "stderrthreshold":
-			// always use stderr for logging
-		default:
-			rootCmd.PersistentFlags().AddGoFlag(gf)
-		}
-	})
 }

--- a/pkg/cmd/BUILD
+++ b/pkg/cmd/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["flag.go"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_spf13_cobra//:go_default_library"],
+)

--- a/pkg/cmd/flag.go
+++ b/pkg/cmd/flag.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"flag"
+
+	"github.com/spf13/cobra"
+)
+
+// InitializeFlags carries over glog flags with new defaults, and makes
+// `flag.Parsed()` to return true.
+func InitializeFlags(rootCmd *cobra.Command) {
+	flag.CommandLine.VisitAll(func(gf *flag.Flag) {
+		rootCmd.PersistentFlags().AddGoFlag(gf)
+	})
+
+	// hack to make flag.Parsed return true such that glog is happy
+	// about the flags having been parsed
+	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
+	_ = flagSet.Parse([]string{})
+	flag.CommandLine = flagSet
+}


### PR DESCRIPTION
This should fix the "logging before flag.Parse" error as below
```
ERROR: logging before flag.Parse: I0823 15:56:28.415665   14113 main.go:154] Use self-signed certificate as the CA certificate
ERROR: logging before flag.Parse: I0823 15:56:28.792499   14113 main.go:137] Istio CA has started
ERROR: logging before flag.Parse: I0823 15:56:28.792522   14113 server.go:107] Starting GRPC server on port 3443
ERROR: logging before flag.Parse: I0823 15:56:28.837063   14113 secret.go:189] Istio secret for service account "default" in namespace "grpc-testing" has been created
```

/assign @myidpt 
/assign @wattli 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
