### PR TITLE
Unifying CA signing interface

### DIFF
--- a/integration/main.go
+++ b/integration/main.go
@@ -193,7 +193,7 @@ func examineSecret(secret *v1.Secret, expectedID string) {
 	cert := secret.Data[controller.CertChainID]
 	root := secret.Data[controller.RootCertID]
 	verifyFields := &testutil.VerifyFields{
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		IsCA:        false,
 	}

--- a/pkg/pki/ca/ca_test.go
+++ b/pkg/pki/ca/ca_test.go
@@ -38,8 +38,20 @@ func TestSelfSignedIstioCA(t *testing.T) {
 
 	name := "foo"
 	namespace := "bar"
+	id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, name)
+	options := CertOptions{
+		Host:       id,
+		RSAKeySize: 1024,
+	}
+	csr, _, err := GenCSR(options)
+	if err != nil {
+		t.Error(err)
+	}
+	cb, err := ca.Sign(csr)
+	if err != nil {
+		t.Error(err)
+	}
 
-	cb, _ := ca.Generate(name, namespace)
 	rcb := ca.GetRootCertificate()
 
 	certPool := x509.NewCertPool()
@@ -80,7 +92,6 @@ func TestSelfSignedIstioCA(t *testing.T) {
 		t.Errorf("Generated certificate does not contain a SAN field")
 	}
 
-	id := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s", namespace, name)
 	rv := asn1.RawValue{Tag: 6, Class: asn1.ClassContextSpecific, Bytes: []byte(id)}
 	bs, err := asn1.Marshal([]asn1.RawValue{rv})
 	if err != nil {

--- a/pkg/pki/ca/generate_cert.go
+++ b/pkg/pki/ca/generate_cert.go
@@ -71,8 +71,8 @@ type CertOptions struct {
 	RSAKeySize int
 }
 
-// The URI scheme for Istio identities.
-const uriScheme = "spiffe"
+// URIScheme is the URI scheme for Istio identities.
+const URIScheme = "spiffe"
 
 // GenCSR generates a X.509 certificate sign request and private key with the given options.
 func GenCSR(options CertOptions) ([]byte, []byte, error) {
@@ -232,7 +232,7 @@ func buildSubjectAltNameExtension(hosts string) *pkix.Extension {
 				ip = eip
 			}
 			ids = append(ids, pki.Identity{Type: pki.TypeIP, Value: ip})
-		} else if strings.HasPrefix(host, uriScheme+":") {
+		} else if strings.HasPrefix(host, URIScheme+":") {
 			ids = append(ids, pki.Identity{Type: pki.TypeURI, Value: []byte(host)})
 		} else {
 			ids = append(ids, pki.Identity{Type: pki.TypeDNS, Value: []byte(host)})

--- a/pkg/server/grpc/server_test.go
+++ b/pkg/server/grpc/server_test.go
@@ -56,10 +56,6 @@ func (ca *mockCA) Sign(csrPEM []byte) ([]byte, error) {
 	return []byte(ca.cert), nil
 }
 
-func (ca *mockCA) Generate(name, ns string) (chain, key []byte) {
-	return nil, nil
-}
-
 func (ca *mockCA) GetRootCertificate() []byte {
 	return nil
 }


### PR DESCRIPTION
Currently the CA exposes two methods:
* `Sign(csrPEM []string)` which is used by the GRPC server
* `Generate(name, namespace []string)` which is used for generating
cert based on K8S service account.

However these two methods are very similar, and this PR removes the
second method completely. After this PR, the K8S secret controller
constructs a CSR locally and uses the `Sign` method to get a
certificate.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
