### PR TITLE
Use megacheck instead of running staticcheck, gosimple and unsued

### DIFF
--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -10,16 +10,14 @@ gometalinter --concurrency=4 --enable-gc --deadline=300s --disable-all\
   --enable=gofmt\
   --enable=goimports\
   --enable=golint --exclude=.pb.go\
-  --enable=gosimple\
   --enable=gotype\
   --enable=ineffassign\
   --enable=interfacer\
   --enable=lll --line-length=120\
+  --enable=megacheck\
   --enable=misspell\
-  --enable=staticcheck\
   --enable=structcheck\
   --enable=unconvert\
-  --enable=unused\
   --enable=varcheck\
   --enable=vet\
   --enable=vetshadow\


### PR DESCRIPTION
Fixed the following linter warning:
```
WARNING: staticcheck, gosimple and unused are all set, using megacheck instead
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

