### PR TITLE
Update bazel rules on generating artifact

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -4,9 +4,7 @@ load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
 pkg_tar(
     name = "istio_ca_tar",
     extension = "tar.gz",
-    files = [
-        "//cmd/istio_ca:istio_ca",
-    ],
+    srcs = [ "//cmd/istio_ca:istio_ca" ],
     mode = "0755",
     package_dir = "/usr/local/bin",
     tags = [ "manual" ],

--- a/tools/deb/BUILD
+++ b/tools/deb/BUILD
@@ -2,16 +2,14 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 
 pkg_tar(
     name = "agent-bin",
-    files = [
-        "//cmd/node_agent",
-    ],
+    srcs = [ "//cmd/node_agent" ],
     mode = "0755",
     package_dir = "/usr/local/bin",
 )
 
 pkg_tar(
     name = "istio-systemd",
-    files = ["istio-auth-node-agent.service"],
+    srcs = ["istio-auth-node-agent.service"],
     mode = "644",
     package_dir = "/lib/systemd/system",
 )


### PR DESCRIPTION
This fixes the following warning:
```
WARNING: /home/yangguan/.cache/bazel/_bazel_yangguan/31ca9274694414f6974e788406092f9b/external/bazel_tools/tools/build_defs/pkg/pkg.bzl:196:9: pkg_tar: renaming non-dict `files` attribute to `srcs`.
WARNING: /home/yangguan/.cache/bazel/_bazel_yangguan/31ca9274694414f6974e788406092f9b/external/bazel_tools/tools/build_defs/pkg/pkg.bzl:196:9: pkg_tar: renaming non-dict `files` attribute to `srcs`.
WARNING: /home/yangguan/.cache/bazel/_bazel_yangguan/31ca9274694414f6974e788406092f9b/external/bazel_tools/tools/build_defs/pkg/pkg.bzl:196:9: pkg_tar: renaming non-dict `files` attribute to `srcs`.
```

/assign @wattli
/assign @costinm 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
