### PR TITLE
Add markdown subcommand to generate documentation for istio_ca

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,12 @@ go_repository(
 )
 
 go_repository(
+    name = "com_github_cpuguy83_go_md2man",
+    commit = "1d903dcb749992f3741d744c0f8376b4bd7eb3e1",
+    importpath = "github.com/cpuguy83/go-md2man",
+)
+
+go_repository(
     name = "com_github_davecgh_go_spew",
     commit = "346938d642f2ec3594ed81d874461961cd0faa76",
     importpath = "github.com/davecgh/go-spew",
@@ -172,6 +178,12 @@ go_repository(
     name = "com_github_pborman_uuid",
     commit = "1b00554d822231195d1babd97ff4a781231955c9",
     importpath = "github.com/pborman/uuid",
+)
+
+go_repository(
+    name = "com_github_russross_blackfriday",
+    commit = "4048872b16cc0fc2c5fd9eacf0ed2c2fedaa0c8c",
+    importpath = "github.com/russross/blackfriday",
 )
 
 go_repository(

--- a/cmd/istio_ca/BUILD
+++ b/cmd/istio_ca/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "markdown.go",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         "//cmd/istio_ca/version:go_default_library",
@@ -12,6 +15,7 @@ go_library(
         "//pkg/server/grpc:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@com_github_spf13_cobra//doc:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",

--- a/cmd/istio_ca/main.go
+++ b/cmd/istio_ca/main.go
@@ -66,6 +66,8 @@ var (
 	opts cliOptions
 
 	rootCmd = &cobra.Command{
+		Use:   "istio_ca",
+		Short: "Istio Certificate Authority (CA)",
 		Run: func(cmd *cobra.Command, args []string) {
 			runCA()
 		},

--- a/cmd/istio_ca/markdown.go
+++ b/cmd/istio_ca/markdown.go
@@ -1,0 +1,40 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+var (
+	markdownOutputDir string
+
+	markdownCmd = &cobra.Command{
+		DisableAutoGenTag: true,
+		Hidden:            true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return doc.GenMarkdownTree(rootCmd, markdownOutputDir)
+		},
+		Short: "Generate markdown documentation for istio_ca",
+		Use:   "markdown",
+	}
+)
+
+func init() {
+	markdownCmd.PersistentFlags().StringVar(&markdownOutputDir, "dir", ".", "Output directory for generated markdown files")
+
+	rootCmd.AddCommand(markdownCmd)
+}

--- a/cmd/istio_ca/markdown.go
+++ b/cmd/istio_ca/markdown.go
@@ -34,7 +34,8 @@ var (
 )
 
 func init() {
-	markdownCmd.PersistentFlags().StringVar(&markdownOutputDir, "dir", ".", "Output directory for generated markdown files")
+	markdownCmd.PersistentFlags().StringVar(&markdownOutputDir, "dir", ".",
+		"Output directory for generated markdown files")
 
 	rootCmd.AddCommand(markdownCmd)
 }


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add `markdown` subcommand to auto generate documentation for istio_ca 
```
/assign @wattli 
/assign @myidpt 