### PR TITLE
Add preliminary AWS support for node agent

### DIFF
--- a/BUILD.ubuntu
+++ b/BUILD.ubuntu
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 docker_build(
     name = "xenial",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -290,6 +290,24 @@ go_repository(
     importpath = "google.golang.org/genproto",
 )
 
+go_repository(
+    name = "com_github_aws_aws-sdk-go",
+    importpath = "github.com/aws/aws-sdk-go",
+    tag = "v1.12.5",
+)
+
+go_repository(
+    name = "com_github_go_ini_ini",
+    importpath = "github.com/go-ini/ini",
+    tag = "v1.28.2",
+)
+
+go_repository(
+    name = "com_github_jmespath_go_jmespath",
+    importpath = "github.com/jmespath/go-jmespath",
+    tag = "0.2.2",
+)
+
 new_http_archive(
     name = "docker_ubuntu",
     build_file = "BUILD.ubuntu",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,20 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.5.2",
+    tag = "0.5.5",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
 
 go_repositories()
+
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.3.0",
+)
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories")
+docker_repositories()
 
 git_repository(
     name = "org_pubref_rules_protobuf",

--- a/cmd/node_agent/main.go
+++ b/cmd/node_agent/main.go
@@ -49,7 +49,7 @@ func init() {
 		"ca-address", "istio-ca:8060", "Istio CA address")
 	flags.StringVar(&naConfig.RootCACertFile, "root-cert",
 		"/etc/certs/root-cert.pem", "Root Certificate file")
-	flags.StringVar(&naConfig.Env, "env", "onprem", "Node Environment : onprem | gcp")
+	flags.StringVar(&naConfig.Env, "env", "onprem", "Node Environment : onprem | gcp | aws")
 
 	cmd.InitializeFlags(rootCmd)
 }

--- a/cmd/node_agent/na/BUILD
+++ b/cmd/node_agent/na/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "gcp.go",
+        "aws.go",
         "nafactory.go",
         "nodeagent.go",
         "onprem.go",

--- a/cmd/node_agent/na/aws.go
+++ b/cmd/node_agent/na/aws.go
@@ -48,7 +48,7 @@ func (na *awsPlatformImpl) IsProperPlatform() bool {
 func (na *awsPlatformImpl) GetServiceIdentity() (string, error) {
 	userdata, err := na.fetcher.GetUserData()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get service identity: %v", err)
+		return "", fmt.Errorf("Failed to get EC2 user data: %v", err)
 	}
 	var dat map[string]string
 	err = json.Unmarshal([]byte(userdata), &dat)

--- a/cmd/node_agent/na/aws.go
+++ b/cmd/node_agent/na/aws.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package na
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	cred "istio.io/auth/pkg/credential"
+)
+
+type awsPlatformImpl struct {
+	fetcher *cred.AwsTokenFetcher
+}
+
+// This is extracted from the same function in gcp.go.
+// Should put the common logic elsewhere in the future.
+func (na *awsPlatformImpl) GetDialOptions(cfg *Config) ([]grpc.DialOption, error) {
+	creds, err := credentials.NewClientTLSFromFile(cfg.RootCACertFile, "")
+	if err != nil {
+		return nil, err
+	}
+
+	options := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	return options, nil
+}
+
+func (na *awsPlatformImpl) IsProperPlatform() bool {
+	return na.fetcher.IsOnAWS()
+}
+
+// Extract service identity from userdata. This function should be
+// pluggable for different AWS deployments in the future.
+func (na *awsPlatformImpl) GetServiceIdentity() (string, error) {
+	userdata, err := na.fetcher.GetUserData()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get service identity: %v", err)
+	}
+	var dat map[string]string
+	err = json.Unmarshal([]byte(userdata), &dat)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get service identity: %v", err)
+	}
+	return dat["APIGEE_POD"], nil
+}

--- a/cmd/node_agent/na/nafactory.go
+++ b/cmd/node_agent/na/nafactory.go
@@ -41,6 +41,8 @@ func NewNodeAgent(cfg *Config) NodeAgent {
 		na.pr = &onPremPlatformImpl{cfg.CertChainFile}
 	case "gcp":
 		na.pr = &gcpPlatformImpl{&cred.GcpTokenFetcher{Aud: fmt.Sprintf("grpc://%s", cfg.IstioCAAddress)}}
+	case "aws":
+		na.pr = &awsPlatformImpl{&cred.AwsTokenFetcher{}}
 	default:
 		glog.Fatalf("Invalid env %s specified", cfg.Env)
 	}

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 pkg_tar(
     name = "istio_ca_tar",
     extension = "tar.gz",
-    files = [
+    srcs = [
         "//cmd/istio_ca:istio_ca",
     ],
     mode = "0755",

--- a/pkg/credential/BUILD
+++ b/pkg/credential/BUILD
@@ -4,5 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = ["token.go"],
     visibility = ["//visibility:public"],
-    deps = ["@com_google_cloud_go//compute/metadata:go_default_library"],
+    deps = [
+         "@com_google_cloud_go//compute/metadata:go_default_library",
+         "@com_github_aws_aws-sdk-go//aws/ec2metadata:go_default_library",
+         "@com_github_aws_aws-sdk-go//aws/session:go_default_library",
+    ],
 )

--- a/pkg/credential/token.go
+++ b/pkg/credential/token.go
@@ -17,6 +17,7 @@ package credential
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -61,8 +62,9 @@ func (fetcher *AwsTokenFetcher) FetchToken() (string, error) {
 			bytes, _ := json.Marshal(doc)
 			return string(bytes), nil
 		}
+		return "", fmt.Errorf("Failed to get EC2 instance identity document: %v", err)
 	}
-	return "", errors.New("unable to get EC2 instance identity document")
+	return "", errors.New("Failed to connect to EC2 metadata service, please make sure this binary is running on an EC2 VM")
 }
 
 // GetUserData fetches the userdata for the current instance

--- a/tools/deb/BUILD
+++ b/tools/deb/BUILD
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 
 pkg_tar(
     name = "agent-bin",
-    files = [
+    srcs = [
         "//cmd/node_agent",
     ],
     mode = "0755",
@@ -11,7 +11,7 @@ pkg_tar(
 
 pkg_tar(
     name = "istio-systemd",
-    files = ["istio-auth-node-agent.service"],
+    srcs = ["istio-auth-node-agent.service"],
     mode = "644",
     package_dir = "/lib/systemd/system",
 )


### PR DESCRIPTION
First step in supporting AWS. To make it truly work we'll need some refactoring in the codebase. For example, `na.createRequest()` needs to be pluggable to correctly populate `NodeAgentCredentials` field in request message.
```release-note
none
```