### PR TITLE
Fix auth node agent start error issue (in release-0.2 branch)

### DIFF
--- a/tools/deb/BUILD
+++ b/tools/deb/BUILD
@@ -1,12 +1,13 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 
+# TODO: also rename the binary to istio-auth-node-agent
 pkg_tar(
     name = "agent-bin",
     files = [
         "//cmd/node_agent",
     ],
     mode = "0755",
-    package_dir = "/usr/local/bin",
+    package_dir = "/usr/local/istio/bin",
 )
 
 pkg_tar(

--- a/tools/deb/istio-auth-node-agent.service
+++ b/tools/deb/istio-auth-node-agent.service
@@ -3,7 +3,7 @@ Description=istio-auth-node-agent: The Istio auth node agent
 Documentation=http://istio.io/
 
 [Service]
-ExecStart=/usr/local/bin/node-agent --logtostderr
+ExecStart=/usr/local/istio/bin/node_agent --logtostderr
 Restart=always
 StartLimitInterval=0
 RestartSec=10


### PR DESCRIPTION
Cherry pick of #270 

Fix auth node agent start error issue (wrong file name)

Fixes `_` /`-` typo in binary name

also without putting generic named binaries in user’s /usr/local/bin

Actual fix for #268 

```release-note
Standalone node agent path fix (debian)
```

(cherry picked from commit f6efb0ab402ae55b7ba5b7b249e3df312422258d)