### PR TITLE
Add credential_type field in Request proto definition

### DIFF
--- a/cmd/node_agent/na/BUILD
+++ b/cmd/node_agent/na/BUILD
@@ -21,6 +21,8 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_x_net//context:go_default_library",
+        "@com_github_aws_aws-sdk-go//aws/ec2metadata:go_default_library",
+        "@com_github_aws_aws-sdk-go//aws/session:go_default_library",
     ],
 )
 

--- a/cmd/node_agent/na/gcp.go
+++ b/cmd/node_agent/na/gcp.go
@@ -82,3 +82,7 @@ func (na *gcpPlatformImpl) GetAgentCredential() ([]byte, error) {
 
 	return []byte(jwtKey), nil
 }
+
+func (na *gcpPlatformImpl) GetCredentialType() string {
+	return "gcp"
+}

--- a/cmd/node_agent/na/nafactory.go
+++ b/cmd/node_agent/na/nafactory.go
@@ -17,6 +17,8 @@ package na
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/golang/glog"
 	cred "istio.io/auth/pkg/credential"
 )
@@ -42,7 +44,7 @@ func NewNodeAgent(cfg *Config) NodeAgent {
 	case "gcp":
 		na.pr = &gcpPlatformImpl{&cred.GcpTokenFetcher{Aud: fmt.Sprintf("grpc://%s", cfg.IstioCAAddress)}}
 	case "aws":
-		na.pr = &awsPlatformImpl{&cred.AwsTokenFetcher{}}
+		na.pr = &awsPlatformImpl{ec2metadata.New(session.Must(session.NewSession()))}
 	default:
 		glog.Fatalf("Invalid env %s specified", cfg.Env)
 	}

--- a/cmd/node_agent/na/nodeagent.go
+++ b/cmd/node_agent/na/nodeagent.go
@@ -37,6 +37,8 @@ type platformSpecificRequest interface {
 	GetServiceIdentity() (string, error)
 	// Get node agent credential
 	GetAgentCredential() ([]byte, error)
+	// Get type of the credential
+	GetCredentialType() string
 }
 
 // CAGrpcClient is for implementing the GRPC client to talk to CA.
@@ -177,6 +179,7 @@ func (na *nodeAgentInternal) createRequest() ([]byte, *pb.Request, error) {
 	return privKey, &pb.Request{
 		CsrPem:              csr,
 		NodeAgentCredential: cred,
+		CredentialType:      na.pr.GetCredentialType(),
 	}, nil
 }
 

--- a/cmd/node_agent/na/nodeagent_test.go
+++ b/cmd/node_agent/na/nodeagent_test.go
@@ -68,6 +68,10 @@ func (f FakePlatformSpecificRequest) GetAgentCredential() ([]byte, error) {
 	return []byte{}, nil
 }
 
+func (f FakePlatformSpecificRequest) GetCredentialType() string {
+	return "fake"
+}
+
 type FakeCAClient struct {
 	Counter  int
 	response *pb.Response

--- a/cmd/node_agent/na/onprem.go
+++ b/cmd/node_agent/na/onprem.go
@@ -67,6 +67,10 @@ func (na *onPremPlatformImpl) GetAgentCredential() ([]byte, error) {
 	return certBytes, nil
 }
 
+func (na *onPremPlatformImpl) GetCredentialType() string {
+	return "onprem"
+}
+
 // getTLSCredentials creates transport credentials that are common to
 // node agent and CA.
 func getTLSCredentials(certificateFile string, keyFile string,

--- a/pkg/credential/BUILD
+++ b/pkg/credential/BUILD
@@ -6,7 +6,5 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
          "@com_google_cloud_go//compute/metadata:go_default_library",
-         "@com_github_aws_aws-sdk-go//aws/ec2metadata:go_default_library",
-         "@com_github_aws_aws-sdk-go//aws/session:go_default_library",
     ],
 )

--- a/pkg/credential/token.go
+++ b/pkg/credential/token.go
@@ -15,13 +15,7 @@
 package credential
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"cloud.google.com/go/compute/metadata"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 // TokenFetcher defines the interface to fetch token.
@@ -34,44 +28,6 @@ type GcpTokenFetcher struct {
 	// aud is the unique URI agreed upon by both the instance and the system verifying the instance's identity.
 	// For more info: https://cloud.google.com/compute/docs/instances/verifying-instance-identity
 	Aud string
-}
-
-// AwsTokenFetcher implements the token fetcher in AWS.
-// It gets the EC2 instance identity document as described
-// in the doc: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
-type AwsTokenFetcher struct {
-}
-
-// IsOnAWS returns if node agent is running on AWS EC2 instance
-func (fetcher *AwsTokenFetcher) IsOnAWS() bool {
-	sess := session.Must(session.NewSession())
-	svc := ec2metadata.New(sess)
-	return svc.Available()
-}
-
-// FetchToken fetches the instance identity document as a string
-// Note: currently AWS Golang SDK does not verify the signature,
-// so this function is not very secure. We expect this bug to
-// be fixed in upstream.
-func (fetcher *AwsTokenFetcher) FetchToken() (string, error) {
-	sess := session.Must(session.NewSession())
-	svc := ec2metadata.New(sess)
-	if svc.Available() {
-		doc, err := svc.GetInstanceIdentityDocument()
-		if err == nil {
-			bytes, _ := json.Marshal(doc)
-			return string(bytes), nil
-		}
-		return "", fmt.Errorf("Failed to get EC2 instance identity document: %v", err)
-	}
-	return "", errors.New("Failed to connect to EC2 metadata service, please make sure this binary is running on an EC2 VM")
-}
-
-// GetUserData fetches the userdata for the current instance
-func (fetcher *AwsTokenFetcher) GetUserData() (string, error) {
-	sess := session.Must(session.NewSession())
-	svc := ec2metadata.New(sess)
-	return svc.GetUserData()
 }
 
 func (fetcher *GcpTokenFetcher) getTokenURI() string {

--- a/proto/ca_service.proto
+++ b/proto/ca_service.proto
@@ -42,6 +42,8 @@ message Request {
   bytes csr_pem = 1;
   // opaque credential for node agent
   bytes node_agent_credential = 2;
+  // type of the node_agent_credential (aws/gcp/onprem/custom...)
+  string credential_type = 3;
 }
 
 message Response {


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
Haven't found a good way to test `aws.go` yet...