### PR TITLE
decouple node agent config from platform config (#294)

### DIFF
--- a/cmd/node_agent/BUILD
+++ b/cmd/node_agent/BUILD
@@ -7,8 +7,10 @@ go_library(
     deps = [
         "//cmd/node_agent/na:go_default_library",
         "//pkg/cmd:go_default_library",
+        "//pkg/platform:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
     ],
 )
 

--- a/cmd/node_agent/main.go
+++ b/cmd/node_agent/main.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-
 	flag "github.com/spf13/pflag"
+
 	"istio.io/auth/cmd/node_agent/na"
 	"istio.io/auth/pkg/cmd"
 	"istio.io/auth/pkg/platform"

--- a/cmd/node_agent/main.go
+++ b/cmd/node_agent/main.go
@@ -15,13 +15,16 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	flag "github.com/spf13/pflag"
 	"istio.io/auth/cmd/node_agent/na"
 	"istio.io/auth/pkg/cmd"
+	"istio.io/auth/pkg/platform"
 )
 
 var (
@@ -29,7 +32,7 @@ var (
 
 	rootCmd = &cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
-			runNodeAgent()
+			runNodeAgent(cmd.Flags())
 		},
 	}
 )
@@ -38,18 +41,15 @@ func init() {
 	na.InitializeConfig(&naConfig)
 
 	flags := rootCmd.Flags()
+	flags.SetOutput(ioutil.Discard) // suppress warnings output during flag parsing
 
 	flags.StringVar(&naConfig.ServiceIdentityOrg, "org", "", "Organization for the cert")
 	flags.IntVar(&naConfig.RSAKeySize, "key-size", 1024, "Size of generated private key")
 	flags.StringVar(&naConfig.IstioCAAddress,
 		"ca-address", "istio-ca:8060", "Istio CA address")
-	flags.StringVar(&naConfig.Env, "env", "onprem", "Node Environment : onprem | gcp | aws")
-	flags.StringVar(&naConfig.PlatformConfig.CertChainFile, "cert-chain",
-		"/etc/certs/cert-chain.pem", "Node Agent identity cert file")
-	flags.StringVar(&naConfig.PlatformConfig.KeyFile,
-		"key", "/etc/certs/key.pem", "Node identity private key file")
-	flags.StringVar(&naConfig.PlatformConfig.RootCACertFile, "root-cert",
-		"/etc/certs/root-cert.pem", "Root Certificate file")
+	flags.StringVar(&naConfig.Env, "env", "onprem", "Node Environment : onprem | gcp | aws | ...")
+	flags.StringVar(&naConfig.ServiceCertFile, "service-cert", "/etc/cert.pem", "Service account certificate location")
+	flags.StringVar(&naConfig.ServiceKeyFile, "service-priv-key", "/etc/key.pem", "Service account private key location")
 
 	cmd.InitializeFlags(rootCmd)
 }
@@ -61,7 +61,23 @@ func main() {
 	}
 }
 
-func runNodeAgent() {
+func runNodeAgent(flags *flag.FlagSet) {
+	cc, err := platform.NewClientConfig(naConfig.Env)
+	if err != nil {
+		glog.Error(err)
+		os.Exit(-1)
+	}
+
+	// parse custom flags
+	cFlags := cc.GetFlagSet()
+	cFlags.AddFlagSet(flags)
+	err = cFlags.Parse(os.Args[1:])
+	if err != nil {
+		glog.Error(err)
+		os.Exit(-1)
+	}
+
+	naConfig.PlatformConfig = cc
 	nodeAgent, err := na.NewNodeAgent(&naConfig)
 	if err != nil {
 		glog.Error(err)

--- a/cmd/node_agent/na/config.go
+++ b/cmd/node_agent/na/config.go
@@ -54,6 +54,12 @@ type Config struct {
 
 	// The Configuration for talking to the platform metadata server.
 	PlatformConfig platform.ClientConfig
+
+	// ServiceCertChainFile ...
+	ServiceCertFile string
+
+	// ServiceKeyFile ...
+	ServiceKeyFile string
 }
 
 // InitializeConfig initializes Config with default values.
@@ -61,5 +67,4 @@ func InitializeConfig(config *Config) {
 	config.CSRInitialRetrialInterval = defaultCSRInitialRetrialInterval
 	config.CSRMaxRetries = defaultCSRMaxRetries
 	config.CSRGracePeriodPercentage = defaultCSRGracePeriodPercentage
-	config.PlatformConfig = platform.ClientConfig{}
 }

--- a/cmd/node_agent/na/config.go
+++ b/cmd/node_agent/na/config.go
@@ -55,10 +55,10 @@ type Config struct {
 	// The Configuration for talking to the platform metadata server.
 	PlatformConfig platform.ClientConfig
 
-	// ServiceCertChainFile ...
+	// File path for service identity certificate
 	ServiceCertFile string
 
-	// ServiceKeyFile ...
+	// File path for service identity private key
 	ServiceKeyFile string
 }
 

--- a/cmd/node_agent/na/nafactory.go
+++ b/cmd/node_agent/na/nafactory.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-
 	"istio.io/auth/pkg/platform"
 	"istio.io/auth/pkg/workload"
 )
@@ -39,18 +38,16 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 		certUtil: CertUtilImpl{},
 	}
 
-	if pc, err := platform.NewClient(cfg.Env, cfg.PlatformConfig, cfg.IstioCAAddress); err == nil {
-		na.pc = pc
-	} else {
+	pc, err := platform.NewClient(cfg.Env, cfg.PlatformConfig, cfg.IstioCAAddress)
+	if err != nil {
 		return nil, err
 	}
+	na.pc = pc
 
-	cAClient := &cAGrpcClientImpl{}
-	na.cAClient = cAClient
+	na.cAClient = &cAGrpcClientImpl{}
 
-	// TODO: Specify files for service identity cert/key instead of node agent files.
 	secretServer, err := workload.NewSecretServer(
-		workload.NewSecretFileServerConfig(cfg.PlatformConfig.CertChainFile, cfg.PlatformConfig.KeyFile))
+		workload.NewSecretFileServerConfig(cfg.ServiceCertFile, cfg.ServiceKeyFile))
 	if err != nil {
 		glog.Fatalf("Workload IO creation error: %v", err)
 	}

--- a/cmd/node_agent/na/nafactory_test.go
+++ b/cmd/node_agent/na/nafactory_test.go
@@ -16,6 +16,8 @@ package na
 
 import (
 	"testing"
+
+	"istio.io/auth/pkg/platform"
 )
 
 func TestNewNodeAgent(t *testing.T) {
@@ -30,13 +32,15 @@ func TestNewNodeAgent(t *testing.T) {
 		},
 		"onprem env test": {
 			config: &Config{
-				Env: "onprem",
+				Env:            "onprem",
+				PlatformConfig: &platform.OnPremClientConfig{},
 			},
 			expectedErr: "",
 		},
 		"gcp env test": {
 			config: &Config{
-				Env: "gcp",
+				Env:            "gcp",
+				PlatformConfig: &platform.GcpClientConfig{},
 			},
 			expectedErr: "",
 		},

--- a/cmd/node_agent/na/nodeagent.go
+++ b/cmd/node_agent/na/nodeagent.go
@@ -42,7 +42,7 @@ func (c *cAGrpcClientImpl) SendCSR(req *pb.Request, pc platform.Client, cfg *Con
 	if cfg.IstioCAAddress == "" {
 		return nil, fmt.Errorf("Istio CA address is empty")
 	}
-	dialOptions, err := pc.GetDialOptions(&cfg.PlatformConfig)
+	dialOptions, err := pc.GetDialOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/platform/BUILD
+++ b/pkg/platform/BUILD
@@ -35,6 +35,7 @@ go_test(
         "aws_config_test.go",
         "gcp_test.go",
         "onprem_test.go",
+        "client_test.go",
     ],
     data = glob(["testdata/*"]),
     library = ":go_default_library",

--- a/pkg/platform/BUILD
+++ b/pkg/platform/BUILD
@@ -7,6 +7,9 @@ go_library(
         "client.go",
         "gcp.go",
         "onprem.go",
+        "aws_config.go",
+        "gcp_config.go",
+        "onprem_config.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -20,6 +23,7 @@ go_library(
         "@com_github_aws_aws-sdk-go//aws/ec2metadata:go_default_library",
         "@com_github_aws_aws-sdk-go//aws/session:go_default_library",
         "@com_github_fullsailor_pkcs7//:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
     ],
 )
 
@@ -28,6 +32,7 @@ go_test(
     size = "small",
     srcs = [
         "aws_test.go",
+        "aws_config_test.go",
         "gcp_test.go",
         "onprem_test.go",
     ],

--- a/pkg/platform/aws.go
+++ b/pkg/platform/aws.go
@@ -54,17 +54,21 @@ vSeDCOUMYQR7R9LINYwouHIziqQYMAkGByqGSM44BAMDLwAwLAIUWXBlk40xTwSw
 
 // AwsClientImpl is the implementation of AWS metadata client.
 type AwsClientImpl struct {
+	cfg    *AwsClientConfig
 	client *ec2metadata.EC2Metadata
 }
 
 // NewAwsClientImpl creates a new AwsClientImpl.
-func NewAwsClientImpl() *AwsClientImpl {
-	return &AwsClientImpl{ec2metadata.New(session.Must(session.NewSession()))}
+func NewAwsClientImpl(c ClientConfig) *AwsClientImpl {
+	return &AwsClientImpl{
+		cfg:    c.(*AwsClientConfig),
+		client: ec2metadata.New(session.Must(session.NewSession())),
+	}
 }
 
 // GetDialOptions returns the GRPC dial options to connect to the CA.
-func (ci *AwsClientImpl) GetDialOptions(cfg *ClientConfig) ([]grpc.DialOption, error) {
-	creds, err := credentials.NewClientTLSFromFile(cfg.RootCACertFile, "")
+func (ci *AwsClientImpl) GetDialOptions() ([]grpc.DialOption, error) {
+	creds, err := credentials.NewClientTLSFromFile(ci.cfg.RootCACertFile, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/platform/aws.go
+++ b/pkg/platform/aws.go
@@ -133,7 +133,7 @@ func (ci *AwsClientImpl) GetAgentCredential() ([]byte, error) {
 	return bytes, nil
 }
 
-// GetCredentialType returns the credential type as "aws".
+// GetCredentialType returns the credential type as "AWS".
 func (ci *AwsClientImpl) GetCredentialType() string {
-	return "aws"
+	return "AWS"
 }

--- a/pkg/platform/aws_config.go
+++ b/pkg/platform/aws_config.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+// AwsClientConfig ...
+type AwsClientConfig struct {
+	// Root CA cert file to validate the gRPC service in CA.
+	RootCACertFile string
+}
+
+// GetFlagSet ...
+func (c *AwsClientConfig) GetFlagSet() *flag.FlagSet {
+	flags := flag.NewFlagSet("aws", flag.ContinueOnError)
+	flags.StringVar(&c.RootCACertFile, "root-cert",
+		"/etc/certs/root-cert.pem", "Root Certificate file")
+	return flags
+}

--- a/pkg/platform/aws_config.go
+++ b/pkg/platform/aws_config.go
@@ -18,13 +18,13 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-// AwsClientConfig ...
+// AwsClientConfig contains configs for aws client
 type AwsClientConfig struct {
 	// Root CA cert file to validate the gRPC service in CA.
 	RootCACertFile string
 }
 
-// GetFlagSet ...
+// GetFlagSet returns the flag set for AWS config
 func (c *AwsClientConfig) GetFlagSet() *flag.FlagSet {
 	flags := flag.NewFlagSet("aws", flag.ContinueOnError)
 	flags.StringVar(&c.RootCACertFile, "root-cert",

--- a/pkg/platform/aws_config_test.go
+++ b/pkg/platform/aws_config_test.go
@@ -1,0 +1,43 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"testing"
+)
+
+func TestAWSConfigDefaultValue(t *testing.T) {
+	c := &AwsClientConfig{}
+
+	flags := c.GetFlagSet()
+	_ = flags.Parse([]string{})
+
+	if c.RootCACertFile != flags.Lookup("root-cert").DefValue {
+		t.Errorf("AWS Default Config Flag: wrong default value. Expected %s, Actual %s",
+			flags.Lookup("root-cert").DefValue, c.RootCACertFile)
+	}
+}
+
+func TestAWSFlag(t *testing.T) {
+	c := &AwsClientConfig{}
+
+	flags := c.GetFlagSet()
+	certLoc := "/etc/root.cert.pem"
+	_ = flags.Parse([]string{"--root-cert", certLoc})
+
+	if c.RootCACertFile != certLoc {
+		t.Errorf("AWS Config Flag: wrong value. Expected %s, Actual %s", certLoc, c.RootCACertFile)
+	}
+}

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ClientConfig is the interface for custom configs
+// ClientConfig is the interface for platform configs
 type ClientConfig interface {
 	GetFlagSet() *flag.FlagSet
 }

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -17,22 +17,18 @@ package platform
 import (
 	"fmt"
 
+	flag "github.com/spf13/pflag"
 	"google.golang.org/grpc"
 )
 
-// ClientConfig consists of the platform client configuration.
-type ClientConfig struct {
-	// Root CA cert file to validate the gRPC service in CA.
-	RootCACertFile string
-	// The private key file
-	KeyFile string
-	// The cert chain file
-	CertChainFile string
+// ClientConfig is the interface for custom configs
+type ClientConfig interface {
+	GetFlagSet() *flag.FlagSet
 }
 
 // Client is the interface for implementing the client to access platform metadata.
 type Client interface {
-	GetDialOptions(*ClientConfig) ([]grpc.DialOption, error)
+	GetDialOptions() ([]grpc.DialOption, error)
 	// Whether the node agent is running on the right platform, e.g., if gcpPlatformImpl should only
 	// run on GCE.
 	IsProperPlatform() bool
@@ -44,15 +40,29 @@ type Client interface {
 	GetCredentialType() string
 }
 
-// NewClient is the function to create implementations of the platform metadata client.
-func NewClient(platform string, config ClientConfig, caAddr string) (Client, error) {
+// NewClientConfig returns the platform config object
+func NewClientConfig(platform string) (ClientConfig, error) {
 	switch platform {
 	case "onprem":
-		return NewOnPremClientImpl(config.CertChainFile), nil
+		return &OnPremClientConfig{}, nil
 	case "gcp":
-		return NewGcpClientImpl(caAddr), nil
+		return &GcpClientConfig{}, nil
 	case "aws":
-		return NewAwsClientImpl(), nil
+		return &AwsClientConfig{}, nil
+	default:
+		return nil, fmt.Errorf("Invalid env %s specified", platform)
+	}
+}
+
+// NewClient is the function to create implementations of the platform metadata client.
+func NewClient(platform string, cfg ClientConfig, caAddr string) (Client, error) {
+	switch platform {
+	case "onprem":
+		return NewOnPremClientImpl(cfg), nil
+	case "gcp":
+		return NewGcpClientImpl(cfg, caAddr), nil
+	case "aws":
+		return NewAwsClientImpl(cfg), nil
 	default:
 		return nil, fmt.Errorf("Invalid env %s specified", platform)
 	}

--- a/pkg/platform/client_test.go
+++ b/pkg/platform/client_test.go
@@ -1,0 +1,132 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	cred "istio.io/auth/pkg/credential"
+)
+
+func TestNewClientConfig(t *testing.T) {
+	testCases := map[string]struct {
+		platform    string
+		cfg         ClientConfig
+		expectedErr string
+	}{
+		"onprem env": {
+			platform: "onprem",
+			cfg:      &OnPremClientConfig{},
+		},
+		"gcp env": {
+			platform: "gcp",
+			cfg:      &GcpClientConfig{},
+		},
+		"aws env": {
+			platform: "aws",
+			cfg:      &AwsClientConfig{},
+		},
+		"unknown env": {
+			platform:    "babel",
+			expectedErr: "Invalid env babel specified",
+		},
+	}
+
+	for id, c := range testCases {
+		cc, err := NewClientConfig(c.platform)
+		if len(c.expectedErr) == 0 {
+			if err == nil {
+				if !reflect.DeepEqual(cc, c.cfg) {
+					t.Errorf("%s: Wrong config returned. Expected %v, Actual %v", id, c.cfg, cc)
+				}
+			} else {
+				t.Errorf("%s: Unexpected err: %v", id, err)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("%s: Succeeded. Error expected: %s", id, c.expectedErr)
+			} else {
+				if err.Error() != c.expectedErr {
+					t.Errorf("%s: Incorrect error message. Expected %s, Actual %s", id, c.expectedErr, err.Error())
+				}
+			}
+		}
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	testCases := map[string]struct {
+		platform       string
+		cfg            ClientConfig
+		caAddr         string
+		expectedErr    string
+		expectedClient Client
+	}{
+		"onprem env": {
+			platform:       "onprem",
+			cfg:            &OnPremClientConfig{},
+			expectedClient: &OnPremClientImpl{&OnPremClientConfig{}},
+		},
+		"gcp env": {
+			platform: "gcp",
+			cfg:      &GcpClientConfig{},
+			expectedClient: &GcpClientImpl{
+				cfg:     &GcpClientConfig{},
+				fetcher: &cred.GcpTokenFetcher{Aud: fmt.Sprintf("grpc://%s", "fake-ca:9999")},
+			},
+			caAddr: "fake-ca:9999",
+		},
+		"aws env": {
+			platform: "aws",
+			cfg:      &AwsClientConfig{},
+			expectedClient: &AwsClientImpl{
+				cfg: &AwsClientConfig{},
+			},
+		},
+		"unknown env": {
+			platform:    "babel",
+			expectedErr: "Invalid env babel specified",
+		},
+	}
+
+	for id, c := range testCases {
+		pc, err := NewClient(c.platform, c.cfg, c.caAddr)
+
+		if _, ok := pc.(*AwsClientImpl); ok {
+			pc := pc.(*AwsClientImpl)
+			pc.client = nil
+		}
+
+		if len(c.expectedErr) == 0 {
+			if err == nil {
+				if !reflect.DeepEqual(pc, c.expectedClient) {
+					t.Errorf("%s: Wrong client returned. Expected %s, Actual %s", id, c.expectedClient, pc)
+				}
+			} else {
+				t.Errorf("%s: Unexpected err: %v", id, err)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("%s: Succeeded. Error expected: %s", id, c.expectedErr)
+			} else {
+				if err.Error() != c.expectedErr {
+					t.Errorf("%s: Incorrect error message. Expected %s, Actual %s", id, c.expectedErr, err.Error())
+				}
+			}
+		}
+	}
+}

--- a/pkg/platform/gcp.go
+++ b/pkg/platform/gcp.go
@@ -98,7 +98,7 @@ func (ci *GcpClientImpl) GetAgentCredential() ([]byte, error) {
 	return []byte(jwtKey), nil
 }
 
-// GetCredentialType returns the credential type as "gcp".
+// GetCredentialType returns the credential type as "GCP".
 func (ci *GcpClientImpl) GetCredentialType() string {
-	return "gcp"
+	return "GCP"
 }

--- a/pkg/platform/gcp_config.go
+++ b/pkg/platform/gcp_config.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+// GcpClientConfig ...
+type GcpClientConfig struct {
+	// Root CA cert file to validate the gRPC service in CA.
+	RootCACertFile string
+}
+
+// GetFlagSet ...
+func (c *GcpClientConfig) GetFlagSet() *flag.FlagSet {
+	flags := flag.NewFlagSet("aws", flag.ContinueOnError)
+	flags.StringVar(&c.RootCACertFile, "root-cert",
+		"/etc/certs/root-cert.pem", "Root Certificate file")
+	return flags
+}

--- a/pkg/platform/gcp_config.go
+++ b/pkg/platform/gcp_config.go
@@ -18,13 +18,13 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-// GcpClientConfig ...
+// GcpClientConfig contains configs for gcp client
 type GcpClientConfig struct {
 	// Root CA cert file to validate the gRPC service in CA.
 	RootCACertFile string
 }
 
-// GetFlagSet ...
+// GetFlagSet returns flag set for gcp client
 func (c *GcpClientConfig) GetFlagSet() *flag.FlagSet {
 	flags := flag.NewFlagSet("aws", flag.ContinueOnError)
 	flags.StringVar(&c.RootCACertFile, "root-cert",

--- a/pkg/platform/gcp_config_test.go
+++ b/pkg/platform/gcp_config_test.go
@@ -1,0 +1,43 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"testing"
+)
+
+func TestGCPConfigDefaultValue(t *testing.T) {
+	c := &GcpClientConfig{}
+
+	flags := c.GetFlagSet()
+	_ = flags.Parse([]string{})
+
+	if c.RootCACertFile != flags.Lookup("root-cert").DefValue {
+		t.Errorf("GCP Default Config Flag: wrong default value. Expected %s, Actual %s",
+			flags.Lookup("root-cert").DefValue, c.RootCACertFile)
+	}
+}
+
+func TestGCPFlag(t *testing.T) {
+	c := &GcpClientConfig{}
+
+	flags := c.GetFlagSet()
+	certLoc := "/etc/root.cert.pem"
+	_ = flags.Parse([]string{"--root-cert", certLoc})
+
+	if c.RootCACertFile != certLoc {
+		t.Errorf("GCP Config Flag: wrong value. Expected %s, Actual %s", certLoc, c.RootCACertFile)
+	}
+}

--- a/pkg/platform/gcp_test.go
+++ b/pkg/platform/gcp_test.go
@@ -101,7 +101,7 @@ func TestGetDialOptions(t *testing.T) {
 		options, err := gcp.GetDialOptions()
 		if len(c.expectedErr) > 0 {
 			if err == nil {
-				t.Errorf("%s: Succeeded. Error expected: %v", id, err)
+				t.Errorf("%s: Succeeded. Error expected: %v", id, c.expectedErr)
 			} else if err.Error() != c.expectedErr {
 				t.Errorf("%s: incorrect error message: %s VS %s",
 					id, err.Error(), c.expectedErr)

--- a/pkg/platform/gcp_test.go
+++ b/pkg/platform/gcp_test.go
@@ -49,14 +49,14 @@ func TestGetDialOptions(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		cfg             *ClientConfig
+		cfg             *GcpClientConfig
 		token           string
 		tokenFetchErr   string
 		expectedErr     string
 		expectedOptions []grpc.DialOption
 	}{
 		"nil configuration": {
-			cfg: &ClientConfig{
+			cfg: &GcpClientConfig{
 				RootCACertFile: "testdata/cert-chain-good.pem",
 			},
 			token:         "abcdef",
@@ -64,7 +64,7 @@ func TestGetDialOptions(t *testing.T) {
 			tokenFetchErr: "Nil configuration passed",
 		},
 		"Token fetch error": {
-			cfg: &ClientConfig{
+			cfg: &GcpClientConfig{
 				RootCACertFile: "testdata/cert-chain-good.pem",
 			},
 			token:         "",
@@ -72,7 +72,7 @@ func TestGetDialOptions(t *testing.T) {
 			tokenFetchErr: "Nil configuration passed",
 		},
 		"Root certificate file read error": {
-			cfg: &ClientConfig{
+			cfg: &GcpClientConfig{
 				RootCACertFile: "testdata/cert-chain-good_not_exist.pem",
 			},
 			token:         token,
@@ -80,7 +80,7 @@ func TestGetDialOptions(t *testing.T) {
 			expectedErr:   "open testdata/cert-chain-good_not_exist.pem: no such file or directory",
 		},
 		"Token fetched": {
-			cfg: &ClientConfig{
+			cfg: &GcpClientConfig{
 				RootCACertFile: "testdata/cert-chain-good.pem",
 			},
 			token:         token,
@@ -93,9 +93,12 @@ func TestGetDialOptions(t *testing.T) {
 	}
 
 	for id, c := range testCases {
-		gcp := GcpClientImpl{&mockTokenFetcher{c.token, c.tokenFetchErr}}
+		gcp := GcpClientImpl{
+			cfg:     c.cfg,
+			fetcher: &mockTokenFetcher{c.token, c.tokenFetchErr},
+		}
 
-		options, err := gcp.GetDialOptions(c.cfg)
+		options, err := gcp.GetDialOptions()
 		if len(c.expectedErr) > 0 {
 			if err == nil {
 				t.Errorf("%s: Succeeded. Error expected: %v", id, err)

--- a/pkg/platform/mock/BUILD
+++ b/pkg/platform/mock/BUILD
@@ -7,7 +7,6 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/platform:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/pkg/platform/mock/fakeclient.go
+++ b/pkg/platform/mock/fakeclient.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc"
-	"istio.io/auth/pkg/platform"
 )
 
 // FakeClient is mocked platform metadata client.
@@ -31,7 +30,7 @@ type FakeClient struct {
 }
 
 // GetDialOptions returns the DialOption field.
-func (f FakeClient) GetDialOptions(*platform.ClientConfig) ([]grpc.DialOption, error) {
+func (f FakeClient) GetDialOptions() ([]grpc.DialOption, error) {
 	if len(f.DialOptionErr) > 0 {
 		return nil, fmt.Errorf(f.DialOptionErr)
 	}

--- a/pkg/platform/onprem.go
+++ b/pkg/platform/onprem.go
@@ -79,9 +79,9 @@ func (ci *OnPremClientImpl) GetAgentCredential() ([]byte, error) {
 	return certBytes, nil
 }
 
-// GetCredentialType returns "onprem".
+// GetCredentialType returns "ONPREM".
 func (ci *OnPremClientImpl) GetCredentialType() string {
-	return "onprem"
+	return "ONPREM"
 }
 
 // getTLSCredentials creates transport credentials that are common to

--- a/pkg/platform/onprem.go
+++ b/pkg/platform/onprem.go
@@ -28,17 +28,17 @@ import (
 
 // OnPremClientImpl is the implementation of on premise metadata client.
 type OnPremClientImpl struct {
-	certFile string
+	cfg *OnPremClientConfig
 }
 
 // NewOnPremClientImpl creates a new OnPremClientImpl.
-func NewOnPremClientImpl(certChainFile string) *OnPremClientImpl {
-	return &OnPremClientImpl{certChainFile}
+func NewOnPremClientImpl(c ClientConfig) *OnPremClientImpl {
+	return &OnPremClientImpl{cfg: c.(*OnPremClientConfig)}
 }
 
 // GetDialOptions returns the GRPC dial options to connect to the CA.
-func (ci *OnPremClientImpl) GetDialOptions(cfg *ClientConfig) ([]grpc.DialOption, error) {
-	transportCreds, err := getTLSCredentials(cfg.CertChainFile, cfg.KeyFile, cfg.RootCACertFile)
+func (ci *OnPremClientImpl) GetDialOptions() ([]grpc.DialOption, error) {
+	transportCreds, err := getTLSCredentials(ci.cfg.CertChainFile, ci.cfg.KeyFile, ci.cfg.RootCACertFile)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (ci *OnPremClientImpl) IsProperPlatform() bool {
 
 // GetServiceIdentity gets the service account from the cert SAN field.
 func (ci *OnPremClientImpl) GetServiceIdentity() (string, error) {
-	certBytes, err := ioutil.ReadFile(ci.certFile)
+	certBytes, err := ioutil.ReadFile(ci.cfg.CertChainFile)
 	if err != nil {
 		return "", err
 	}
@@ -72,9 +72,9 @@ func (ci *OnPremClientImpl) GetServiceIdentity() (string, error) {
 
 // GetAgentCredential passes the certificate to control plane to authenticate
 func (ci *OnPremClientImpl) GetAgentCredential() ([]byte, error) {
-	certBytes, err := ioutil.ReadFile(ci.certFile)
+	certBytes, err := ioutil.ReadFile(ci.cfg.CertChainFile)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read cert file: %s", ci.certFile)
+		return nil, fmt.Errorf("Failed to read cert file: %s", ci.cfg.CertChainFile)
 	}
 	return certBytes, nil
 }

--- a/pkg/platform/onprem_config.go
+++ b/pkg/platform/onprem_config.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+// OnPremClientConfig ...
+type OnPremClientConfig struct {
+	// Root CA cert file to validate the gRPC service in CA.
+	RootCACertFile string
+	// The private key file
+	KeyFile string
+	// The cert chain file
+	CertChainFile string
+}
+
+// GetFlagSet ...
+func (c *OnPremClientConfig) GetFlagSet() *flag.FlagSet {
+	flags := flag.NewFlagSet("onprem", flag.ContinueOnError)
+	flags.StringVar(&c.CertChainFile, "cert-chain",
+		"/etc/certs/cert-chain.pem", "Node Agent identity cert file")
+	flags.StringVar(&c.KeyFile,
+		"key", "/etc/certs/key.pem", "Node identity private key file")
+	flags.StringVar(&c.RootCACertFile, "root-cert",
+		"/etc/certs/root-cert.pem", "Root Certificate file")
+	return flags
+}

--- a/pkg/platform/onprem_config.go
+++ b/pkg/platform/onprem_config.go
@@ -18,7 +18,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-// OnPremClientConfig ...
+// OnPremClientConfig contains configs for onprem client
 type OnPremClientConfig struct {
 	// Root CA cert file to validate the gRPC service in CA.
 	RootCACertFile string
@@ -28,7 +28,7 @@ type OnPremClientConfig struct {
 	CertChainFile string
 }
 
-// GetFlagSet ...
+// GetFlagSet returns flag set for onprem client
 func (c *OnPremClientConfig) GetFlagSet() *flag.FlagSet {
 	flags := flag.NewFlagSet("onprem", flag.ContinueOnError)
 	flags.StringVar(&c.CertChainFile, "cert-chain",

--- a/pkg/platform/onprem_config_test.go
+++ b/pkg/platform/onprem_config_test.go
@@ -1,0 +1,67 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"testing"
+)
+
+func TestOnpremConfigDefaultValue(t *testing.T) {
+	c := &OnPremClientConfig{}
+
+	flags := c.GetFlagSet()
+	_ = flags.Parse([]string{})
+
+	if c.RootCACertFile != flags.Lookup("root-cert").DefValue {
+		t.Errorf("Onprem Default Config Flag: wrong default value. Expected %s, Actual %s",
+			flags.Lookup("root-cert").DefValue, c.RootCACertFile)
+	}
+
+	if c.KeyFile != flags.Lookup("key").DefValue {
+		t.Errorf("Onprem Default Config Flag: wrong default value. Expected %s, Actual %s",
+			flags.Lookup("key").DefValue, c.KeyFile)
+	}
+
+	if c.CertChainFile != flags.Lookup("cert-chain").DefValue {
+		t.Errorf("Onprem Default Config Flag: wrong default value. Expected %s, Actual %s",
+			flags.Lookup("cert-chain").DefValue, c.CertChainFile)
+	}
+}
+
+func TestOnPremFlag(t *testing.T) {
+	c := &OnPremClientConfig{}
+
+	flags := c.GetFlagSet()
+	certLoc := "/etc/cert-chain.pem"
+	keyLoc := "/etc/key.pem"
+	rootLoc := "/etc/root-cert.pem"
+	_ = flags.Parse([]string{
+		"--cert-chain", certLoc,
+		"--key", keyLoc,
+		"--root-cert", rootLoc,
+	})
+
+	if c.CertChainFile != certLoc {
+		t.Errorf("Onprem Config: wrong value. Actual %s, Expected %s", c.CertChainFile, certLoc)
+	}
+
+	if c.KeyFile != keyLoc {
+		t.Errorf("Onprem Config: wrong value. Actual %s, Expected %s", c.KeyFile, keyLoc)
+	}
+
+	if c.RootCACertFile != rootLoc {
+		t.Errorf("Onprem Config: wrong value. Actual %s, Expected %s", c.RootCACertFile, rootLoc)
+	}
+}

--- a/pkg/platform/onprem_test.go
+++ b/pkg/platform/onprem_test.go
@@ -49,7 +49,7 @@ func TestGetServiceIdentity(t *testing.T) {
 	}
 
 	for id, c := range testCases {
-		onprem := OnPremClientImpl{c.filename}
+		onprem := OnPremClientImpl{&OnPremClientConfig{CertChainFile: c.filename}}
 		identity, err := onprem.GetServiceIdentity()
 		if c.expectedErr != "" {
 			if err == nil {
@@ -65,11 +65,11 @@ func TestGetServiceIdentity(t *testing.T) {
 
 func TestGetTLSCredentials(t *testing.T) {
 	testCases := map[string]struct {
-		config      *ClientConfig
+		config      *OnPremClientConfig
 		expectedErr string
 	}{
 		"Good cert": {
-			config: &ClientConfig{
+			config: &OnPremClientConfig{
 				CertChainFile:  "testdata/cert-from-root-good.pem",
 				KeyFile:        "testdata/key-from-root-good.pem",
 				RootCACertFile: "testdata/cert-root-good.pem",
@@ -77,7 +77,7 @@ func TestGetTLSCredentials(t *testing.T) {
 			expectedErr: "",
 		},
 		"Loading failure": {
-			config: &ClientConfig{
+			config: &OnPremClientConfig{
 				CertChainFile:  "testdata/cert-from-root-goo.pem",
 				KeyFile:        "testdata/cert-from-root-not-exist.pem",
 				RootCACertFile: "testdata/cert-root-good.pem",
@@ -85,7 +85,7 @@ func TestGetTLSCredentials(t *testing.T) {
 			expectedErr: "Cannot load key pair: open testdata/cert-from-root-goo.pem: no such file or directory",
 		},
 		"Loading root cert failure": {
-			config: &ClientConfig{
+			config: &OnPremClientConfig{
 				CertChainFile:  "testdata/cert-from-root-good.pem",
 				KeyFile:        "testdata/key-from-root-good.pem",
 				RootCACertFile: "testdata/cert-root-not-exist.pem",
@@ -95,9 +95,9 @@ func TestGetTLSCredentials(t *testing.T) {
 	}
 
 	for id, c := range testCases {
-		onprem := OnPremClientImpl{""}
+		onprem := OnPremClientImpl{cfg: c.config}
 
-		_, err := onprem.GetDialOptions(c.config)
+		_, err := onprem.GetDialOptions()
 		if len(c.expectedErr) > 0 {
 			if err == nil {
 				t.Errorf("%s: Succeeded. Error expected: %v", id, err)
@@ -135,7 +135,7 @@ func TestGetAgentCredential(t *testing.T) {
 	}
 
 	for id, c := range testCases {
-		onprem := OnPremClientImpl{c.filename}
+		onprem := OnPremClientImpl{&OnPremClientConfig{CertChainFile: c.filename}}
 		cred, err := onprem.GetAgentCredential()
 		if c.expectedErr != "" {
 			if err == nil {


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
(Sorry this PR is a little large...) 

1. Cmd flag parsing now happens in two phases: first flags for node agent are parsed; then platform flags are added based on the env flag and `os.Args` are parsed again.
2. `PlatformConfig` is now an interface with `GetFlagSet()` method. Its implementation should also contain platform config variables which are automatically populated by `pflag` library. (See `GetFlagSet()` implementation.)
3. To make compilation work, I also added `--service-cert` and `--service-priv-key` options for node agent.

A possible break change is that platform flags have to be specified after node agent flags, otherwise the node agent flag parsing would fail. This is due to the limit in `pflag` library that it can't skip unrecognized flags.